### PR TITLE
Fix reference element references for extruded elements

### DIFF
--- a/FIAT/finite_element.py
+++ b/FIAT/finite_element.py
@@ -168,7 +168,8 @@ def _facet_support_dofs(elem, quad, facet_transform, facets):
     eps = 1.e-8  # Is this a safe value?
 
     weights = quad.get_weights()
-    dim = elem.ref_el.get_spatial_dimension()
+    ref_el = elem.get_reference_element()
+    dim = ref_el.get_spatial_dimension()
 
     result = {}
     for f in facets:

--- a/FIAT/tensor_product.py
+++ b/FIAT/tensor_product.py
@@ -352,11 +352,12 @@ def horiz_facet_support_dofs(elem):
     corresponding basis functions take non-zero values."""
     if not hasattr(elem, "_horiz_facet_support_dofs"):
         # Extruded cells only
-        assert isinstance(elem.ref_el, TensorProductCell)
+        ref_el = elem.get_reference_element()
+        assert isinstance(ref_el, TensorProductCell)
 
-        q = make_quadrature(elem.ref_el.A, max(2*elem.degree(), 1))
-        ft = lambda f: elem.ref_el.get_horiz_facet_transform(f)
-        dim = elem.ref_el.A.get_spatial_dimension()
+        q = make_quadrature(ref_el.A, max(2*elem.degree(), 1))
+        ft = lambda f: ref_el.get_horiz_facet_transform(f)
+        dim = ref_el.A.get_spatial_dimension()
         facets = elem.entity_dofs()[(dim, 0)].keys()
         elem._horiz_facet_support_dofs = _facet_support_dofs(elem, q, ft, facets)
 


### PR DESCRIPTION
Use elem.get_reference_element() instead of elem.ref_el in extruded elements.