### PR TITLE
Serendipity and dPc fix on TPCs

### DIFF
--- a/FIAT/P0.py
+++ b/FIAT/P0.py
@@ -41,7 +41,7 @@ class P0Dual(dual_set.DualSet):
             for entity in sorted(top[dim]):
                 entity_ids[dim][entity] = []
 
-        entity_ids[sd] = {0: [0]}
+        entity_ids[dim] = {0: [0]}
 
         super(P0Dual, self).__init__(nodes, ref_el, entity_ids)
 

--- a/FIAT/discontinuous_pc.py
+++ b/FIAT/discontinuous_pc.py
@@ -38,7 +38,6 @@ hypercube_simplex_map = {Point(): Point(),
 
 def flatten_reference_element(ref_el):
     """Returns a flattened cube corresponding to a given tensor product cell."""
-    print(np.sum(ref_el.get_dimension()))
     if np.sum(ref_el.get_dimension()) == 2:
         return UFCQuadrilateral()
     elif np.sum(ref_el.get_dimension()) == 3:
@@ -93,7 +92,6 @@ class DPCDualSet(dual_set.DualSet):
 
         cur = 0
         for dim in sorted(top):
-            entity_ids[dim] = {}
             for entity in sorted(top[dim]):
                 pts_cur = hypercube_simplex_map[flat_el].make_points(dim, entity, degree)
                 pts_cur = [tuple(np.matmul(A, np.array(x)) + b) for x in pts_cur]
@@ -105,6 +103,7 @@ class DPCDualSet(dual_set.DualSet):
 
         cube_topology = ref_el.get_topology()
         for dim in sorted(cube_topology):
+            entity_ids[dim] = {}
             for entity in sorted(cube_topology[dim]):
                 entity_ids[dim][entity] = []
 

--- a/FIAT/serendipity.py
+++ b/FIAT/serendipity.py
@@ -193,12 +193,12 @@ def v_lambda_0(dim, dx, dy, dz):
 def e_lambda_0(i, dim, dx, dy, dz, x_mid, y_mid, z_mid):
 
     if dim == 2:
-        EL = tuple([-leg(j, y_mid) * dy[0] * dy[1] * a for a in dx for j in range(i-1)] +
-                   [-leg(j, x_mid) * dx[0] * dx[1] * b for b in dy for j in range(i-1)])
+        EL = tuple([-leg(j, y_mid) * dy[0] * dy[1] * a for a in dx for j in range(i-1)]
+                   + [-leg(j, x_mid) * dx[0] * dx[1] * b for b in dy for j in range(i-1)])
     else:
-        EL = tuple([-leg(j, x_mid) * dx[0] * dx[1] * b * c for b in dy for c in dz for j in range(i-1)] +
-                   [-leg(j, y_mid) * dy[0] * dy[1] * a * c for c in dz for a in dx for j in range(i-1)] +
-                   [-leg(j, z_mid) * dz[0] * dz[1] * a * b for a in dx for b in dy for j in range(i-1)])
+        EL = tuple([-leg(j, x_mid) * dx[0] * dx[1] * b * c for b in dy for c in dz for j in range(i-1)]
+                   + [-leg(j, y_mid) * dy[0] * dy[1] * a * c for c in dz for a in dx for j in range(i-1)]
+                   + [-leg(j, z_mid) * dz[0] * dz[1] * a * b for a in dx for b in dy for j in range(i-1)])
 
     return EL
 
@@ -210,11 +210,11 @@ def f_lambda_0(i, dim, dx, dy, dz, x_mid, y_mid, z_mid):
                     for k in range(4, i + 1) for j in range(k-3)])
     else:
         FL = tuple([leg(j, x_mid) * leg(k-4-j, y_mid) * dx[0] * dx[1] * dy[0] * dy[1] * c
-                    for k in range(4, i + 1) for j in range(i-3) for c in dz] +
-                   [leg(j, z_mid) * leg(k-4-j, x_mid) * dx[0] * dx[1] * dz[0] * dz[1] * b
-                    for k in range(4, i + 1) for j in range(i-3) for b in dy] +
-                   [leg(j, y_mid) * leg(k-4-j, z_mid) * dy[0] * dy[1] * dz[0] * dz[1] * a
-                    for k in range(4, i + 1) for j in range(i-3) for a in dx])
+                    for k in range(4, i + 1) for j in range(i-3) for c in dz]
+                   + [leg(j, z_mid) * leg(k-4-j, x_mid) * dx[0] * dx[1] * dz[0] * dz[1] * b
+                      for k in range(4, i + 1) for j in range(i-3) for b in dy]
+                   + [leg(j, y_mid) * leg(k-4-j, z_mid) * dy[0] * dy[1] * dz[0] * dz[1] * a
+                      for k in range(4, i + 1) for j in range(i-3) for a in dx])
 
     return FL
 
@@ -223,8 +223,8 @@ def i_lambda_0(i, dx, dy, dz, x_mid, y_mid, z_mid):
 
     assert i >= 6, 'invalid value for i'
 
-    IL = tuple([-leg(l-6-j, x_mid) * leg(j-k, y_mid) * leg(k, z_mid) *
-                dx[0] * dx[1] * dy[0] * dy[1] * dz[0] * dz[1]
+    IL = tuple([-leg(l-6-j, x_mid) * leg(j-k, y_mid) * leg(k, z_mid)
+                * dx[0] * dx[1] * dy[0] * dy[1] * dz[0] * dz[1]
                 for l in range(6, i + 1) for j in range(i-5) for k in range(j+1)])
 
     return IL

--- a/FIAT/serendipity.py
+++ b/FIAT/serendipity.py
@@ -23,6 +23,8 @@ from FIAT.finite_element import FiniteElement
 from FIAT.lagrange import Lagrange
 from FIAT.dual_set import make_entity_closure_ids
 from FIAT.polynomial_set import mis
+from FIAT.discontinuous_pc import flatten_reference_element
+from FIAT.reference_element import compute_unflattening_map
 
 x, y, z = symbols('x y z')
 variables = (x, y, z)
@@ -50,11 +52,12 @@ class Serendipity(FiniteElement):
 
     def __init__(self, ref_el, degree):
 
-        dim = ref_el.get_spatial_dimension()
-        topology = ref_el.get_topology()
+        flat_el = flatten_reference_element(ref_el)
+        dim = flat_el.get_spatial_dimension()
+        flat_topology = flat_el.get_topology()
 
         x, y, z = symbols('x y z')
-        verts = ref_el.get_vertices()
+        verts = flat_el.get_vertices()
 
         dx = ((verts[-1][0] - x)/(verts[-1][0] - verts[0][0]), (x - verts[0][0])/(verts[-1][0] - verts[0][0]))
         dy = ((verts[-1][1] - y)/(verts[-1][1] - verts[0][1]), (y - verts[0][1])/(verts[-1][1] - verts[0][1]))
@@ -75,24 +78,24 @@ class Serendipity(FiniteElement):
         entity_ids = {}
         cur = 0
 
-        for top_dim, entities in topology.items():
+        for top_dim, entities in flat_topology.items():
             entity_ids[top_dim] = {}
             for entity in entities:
                 entity_ids[top_dim][entity] = []
 
-        for j in sorted(topology[0]):
+        for j in sorted(flat_topology[0]):
             entity_ids[0][j] = [cur]
             cur = cur + 1
 
         EL += e_lambda_0(degree, dim, dx, dy, dz, x_mid, y_mid, z_mid)
 
-        for j in sorted(topology[1]):
+        for j in sorted(flat_topology[1]):
             entity_ids[1][j] = list(range(cur, cur + degree - 1))
             cur = cur + degree - 1
 
         FL += f_lambda_0(degree, dim, dx, dy, dz, x_mid, y_mid, z_mid)
 
-        for j in sorted(topology[2]):
+        for j in sorted(flat_topology[2]):
             entity_ids[2][j] = list(range(cur, cur + tr(degree)))
             cur = cur + tr(degree)
 
@@ -110,9 +113,26 @@ class Serendipity(FiniteElement):
         super(Serendipity, self).__init__(ref_el=ref_el, dual=None, order=degree, formdegree=formdegree)
 
         self.basis = {(0,)*dim: Array(s_list)}
-        self.entity_ids = entity_ids
-        self.entity_closure_ids = make_entity_closure_ids(ref_el, entity_ids)
+
+        topology = ref_el.get_topology()
+        unflattening_map = compute_unflattening_map(topology)
+        unflattened_entity_ids = {}
+        unflattened_entity_closure_ids = {}
+
+        entity_closure_ids = make_entity_closure_ids(flat_el, entity_ids)
+
+        for dim, entities in sorted(topology.items()):
+            unflattened_entity_ids[dim] = {}
+            unflattened_entity_closure_ids[dim] = {}
+        for dim, entities in sorted(flat_topology.items()):
+            for entity in entities:
+                unflat_dim, unflat_entity = unflattening_map[(dim, entity)]
+                unflattened_entity_ids[unflat_dim][unflat_entity] = entity_ids[dim][entity]
+                unflattened_entity_closure_ids[unflat_dim][unflat_entity] = entity_closure_ids[dim][entity]
+        self.entity_ids = unflattened_entity_ids
+        self.entity_closure_ids = unflattened_entity_closure_ids
         self._degree = degree
+        self.flat_el = flat_el
 
     def degree(self):
         return self._degree + 1
@@ -136,7 +156,7 @@ class Serendipity(FiniteElement):
         points = list(map(transform, points))
 
         phivals = {}
-        dim = self.ref_el.get_spatial_dimension()
+        dim = self.flat_el.get_spatial_dimension()
         if dim <= 1:
             raise NotImplementedError('no tabulate method for serendipity elements of dimension 1 or less.')
         if dim >= 4:
@@ -178,7 +198,7 @@ class Serendipity(FiniteElement):
         raise NotImplementedError
 
     def space_dimension(self):
-        return len(self.basis[(0,)*self.ref_el.get_spatial_dimension()])
+        return len(self.basis[(0,)*self.flat_el.get_spatial_dimension()])
 
 
 def v_lambda_0(dim, dx, dy, dz):
@@ -197,9 +217,9 @@ def e_lambda_0(i, dim, dx, dy, dz, x_mid, y_mid, z_mid):
         EL = tuple([-leg(j, y_mid) * dy[0] * dy[1] * a for a in dx for j in range(i-1)]
                    + [-leg(j, x_mid) * dx[0] * dx[1] * b for b in dy for j in range(i-1)])
     else:
-        EL = tuple([-leg(j, x_mid) * dx[0] * dx[1] * b * c for b in dy for c in dz for j in range(i-1)]
-                   + [-leg(j, y_mid) * dy[0] * dy[1] * a * c for c in dz for a in dx for j in range(i-1)]
-                   + [-leg(j, z_mid) * dz[0] * dz[1] * a * b for a in dx for b in dy for j in range(i-1)])
+        EL = tuple([-leg(j, z_mid) * dz[0] * dz[1] * a * b for b in dx for a in dy for j in range(i-1)]
+                   + [-leg(j, y_mid) * dy[0] * dy[1] * a * c for a in dx for c in dz for j in range(i-1)]
+                   + [-leg(j, x_mid) * dx[0] * dx[1] * b * c for c in dy for b in dz for j in range(i-1)])
 
     return EL
 
@@ -210,12 +230,12 @@ def f_lambda_0(i, dim, dx, dy, dz, x_mid, y_mid, z_mid):
         FL = tuple([leg(j, x_mid) * leg(k-4-j, y_mid) * dx[0] * dx[1] * dy[0] * dy[1]
                     for k in range(4, i + 1) for j in range(k-3)])
     else:
-        FL = tuple([leg(j, x_mid) * leg(k-4-j, y_mid) * dx[0] * dx[1] * dy[0] * dy[1] * c
-                    for k in range(4, i + 1) for j in range(k-3) for c in dz]
+        FL = tuple([leg(j, y_mid) * leg(k-4-j, z_mid) * dy[0] * dy[1] * dz[0] * dz[1] * a
+                    for a in dx for k in range(4, i + 1) for j in range(k-3)]
                    + [leg(j, z_mid) * leg(k-4-j, x_mid) * dx[0] * dx[1] * dz[0] * dz[1] * b
-                      for k in range(4, i + 1) for j in range(k-3) for b in dy]
-                   + [leg(j, y_mid) * leg(k-4-j, z_mid) * dy[0] * dy[1] * dz[0] * dz[1] * a
-                      for k in range(4, i + 1) for j in range(k-3) for a in dx])
+                      for b in dy for k in range(4, i + 1) for j in range(k-3)]
+                   + [leg(j, x_mid) * leg(k-4-j, y_mid) * dx[0] * dx[1] * dy[0] * dy[1] * c
+                      for c in dz for k in range(4, i + 1) for j in range(k-3)])
 
     return FL
 

--- a/FIAT/serendipity.py
+++ b/FIAT/serendipity.py
@@ -101,6 +101,7 @@ class Serendipity(FiniteElement):
 
             entity_ids[3] = {}
             entity_ids[3][0] = list(range(cur, cur + len(IL)))
+            cur = cur + len(IL)
 
         s_list = VL + EL + FL + IL
         assert len(s_list) == cur
@@ -210,21 +211,19 @@ def f_lambda_0(i, dim, dx, dy, dz, x_mid, y_mid, z_mid):
                     for k in range(4, i + 1) for j in range(k-3)])
     else:
         FL = tuple([leg(j, x_mid) * leg(k-4-j, y_mid) * dx[0] * dx[1] * dy[0] * dy[1] * c
-                    for k in range(4, i + 1) for j in range(i-3) for c in dz]
+                    for k in range(4, i + 1) for j in range(k-3) for c in dz]
                    + [leg(j, z_mid) * leg(k-4-j, x_mid) * dx[0] * dx[1] * dz[0] * dz[1] * b
-                      for k in range(4, i + 1) for j in range(i-3) for b in dy]
+                      for k in range(4, i + 1) for j in range(k-3) for b in dy]
                    + [leg(j, y_mid) * leg(k-4-j, z_mid) * dy[0] * dy[1] * dz[0] * dz[1] * a
-                      for k in range(4, i + 1) for j in range(i-3) for a in dx])
+                      for k in range(4, i + 1) for j in range(k-3) for a in dx])
 
     return FL
 
 
 def i_lambda_0(i, dx, dy, dz, x_mid, y_mid, z_mid):
 
-    assert i >= 6, 'invalid value for i'
-
     IL = tuple([-leg(l-6-j, x_mid) * leg(j-k, y_mid) * leg(k, z_mid)
                 * dx[0] * dx[1] * dy[0] * dy[1] * dz[0] * dz[1]
-                for l in range(6, i + 1) for j in range(i-5) for k in range(j+1)])
+                for l in range(6, i + 1) for j in range(l-5) for k in range(j+1)])
 
     return IL


### PR DESCRIPTION
Fixed the Serendipity and dPc elements on TPCs. A new function `flatten_reference_element` maps the TPC onto a UFC cell where the element is constructed. The entity dofs are then mapped back to the corresponding TPC numbering