### PR TITLE
Serendipity and dPc fix on TPCs

### DIFF
--- a/FIAT/P0.py
+++ b/FIAT/P0.py
@@ -41,7 +41,7 @@ class P0Dual(dual_set.DualSet):
             for entity in sorted(top[dim]):
                 entity_ids[dim][entity] = []
 
-        entity_ids[sd] = {0: [0]}
+        entity_ids[dim] = {0: [0]}
 
         super(P0Dual, self).__init__(nodes, ref_el, entity_ids)
 

--- a/FIAT/P0.py
+++ b/FIAT/P0.py
@@ -34,7 +34,6 @@ class P0Dual(dual_set.DualSet):
 
         nodes = [functional.PointEvaluation(ref_el, bary)]
         entity_ids = {}
-        sd = ref_el.get_spatial_dimension()
         top = ref_el.get_topology()
         for dim in sorted(top):
             entity_ids[dim] = {}

--- a/FIAT/discontinuous_pc.py
+++ b/FIAT/discontinuous_pc.py
@@ -25,7 +25,8 @@ from FIAT.reference_element import (Point,
                                     UFCHexahedron,
                                     UFCTriangle,
                                     UFCTetrahedron,
-                                    make_affine_mapping)
+                                    make_affine_mapping,
+                                    flatten_reference_element)
 from FIAT.P0 import P0Dual
 import numpy as np
 
@@ -34,16 +35,6 @@ hypercube_simplex_map = {Point(): Point(),
                          UFCInterval(): UFCInterval(),
                          UFCQuadrilateral(): UFCTriangle(),
                          UFCHexahedron(): UFCTetrahedron()}
-
-
-def flatten_reference_element(ref_el):
-    """Returns a flattened cube corresponding to a given tensor product cell."""
-    if np.sum(ref_el.get_dimension()) == 2:
-        return UFCQuadrilateral()
-    elif np.sum(ref_el.get_dimension()) == 3:
-        return UFCHexahedron()
-    else:
-        raise TypeError('Invalid cell type')
 
 
 class DPC0(finite_element.CiarletElement):

--- a/FIAT/discontinuous_pc.py
+++ b/FIAT/discontinuous_pc.py
@@ -38,7 +38,6 @@ hypercube_simplex_map = {Point(): Point(),
 
 def flatten_reference_element(ref_el):
     """Returns a flattened cube corresponding to a given tensor product cell."""
-    print(np.sum(ref_el.get_dimension()))
     if np.sum(ref_el.get_dimension()) == 2:
         return UFCQuadrilateral()
     elif np.sum(ref_el.get_dimension()) == 3:
@@ -93,7 +92,6 @@ class DPCDualSet(dual_set.DualSet):
 
         cur = 0
         for dim in sorted(top):
-            entity_ids[dim] = {}
             for entity in sorted(top[dim]):
                 pts_cur = hypercube_simplex_map[flat_el].make_points(dim, entity, degree)
                 pts_cur = [tuple(np.matmul(A, np.array(x)) + b) for x in pts_cur]
@@ -105,6 +103,7 @@ class DPCDualSet(dual_set.DualSet):
 
         cube_topology = ref_el.get_topology()
         for dim in sorted(cube_topology):
+            entity_ids[dim] = {}
             for entity in sorted(cube_topology[dim]):
                 entity_ids[dim][entity] = []
 

--- a/FIAT/discontinuous_pc.py
+++ b/FIAT/discontinuous_pc.py
@@ -26,7 +26,7 @@ from FIAT.reference_element import (Point,
                                     UFCTriangle,
                                     UFCTetrahedron,
                                     make_affine_mapping,
-                                    flatten_reference_element)
+                                    flatten_reference_cube)
 from FIAT.P0 import P0Dual
 import numpy as np
 
@@ -39,7 +39,7 @@ hypercube_simplex_map = {Point(): Point(),
 
 class DPC0(finite_element.CiarletElement):
     def __init__(self, ref_el):
-        flat_el = flatten_reference_element(ref_el)
+        flat_el = flatten_reference_cube(ref_el)
         poly_set = polynomial_set.ONPolynomialSet(hypercube_simplex_map[flat_el], 0)
         dual = P0Dual(ref_el)
         degree = 0
@@ -106,7 +106,7 @@ class HigherOrderDPC(finite_element.CiarletElement):
     """The DPC finite element.  It is what it is."""
 
     def __init__(self, ref_el, degree):
-        flat_el = flatten_reference_element(ref_el)
+        flat_el = flatten_reference_cube(ref_el)
         poly_set = polynomial_set.ONPolynomialSet(hypercube_simplex_map[flat_el], degree)
         dual = DPCDualSet(ref_el, flat_el, degree)
         formdegree = flat_el.get_spatial_dimension()  # n-form

--- a/FIAT/reference_element.py
+++ b/FIAT/reference_element.py
@@ -1026,12 +1026,10 @@ def tuple_sum(tree):
 
 
 def is_hypercube(cell):
-    if isinstance(cell, (DefaultLine, UFCInterval, UFCQuadrilateral, UFCHexahedron)):
-        return True
-    elif isinstance(cell, TensorProductCell):
+    if isinstance(cell, TensorProductCell):
         return reduce(lambda a, b: a and b, [is_hypercube(c) for c in cell.cells])
     else:
-        return False
+        return isinstance(cell, (DefaultLine, UFCInterval, UFCQuadrilateral, UFCHexahedron))
 
 
 def flatten_reference_cube(ref_el):

--- a/FIAT/reference_element.py
+++ b/FIAT/reference_element.py
@@ -1025,13 +1025,13 @@ def tuple_sum(tree):
         return tree
 
 
-def flatten_reference_element(ref_el):
+def flatten_reference_cube(ref_el):
     """Returns a flattened cube corresponding to a given tensor product cell."""
-    if numpy.sum(ref_el.get_dimension()) == 1:
-        return UFCInterval()
-    elif numpy.sum(ref_el.get_dimension()) == 2:
+    if numpy.sum(ref_el.get_dimension()) <= 1:
+        return ref_el
+    elif numpy.sum(ref_el.get_dimension()) == 2 and len(ref_el.vertices) == 4:
         return UFCQuadrilateral()
-    elif numpy.sum(ref_el.get_dimension()) == 3:
+    elif numpy.sum(ref_el.get_dimension()) == 3 and len(ref_el.vertices) == 8:
         return UFCHexahedron()
     else:
         raise TypeError('Invalid cell type')

--- a/FIAT/reference_element.py
+++ b/FIAT/reference_element.py
@@ -1025,6 +1025,18 @@ def tuple_sum(tree):
         return tree
 
 
+def flatten_reference_element(ref_el):
+    """Returns a flattened cube corresponding to a given tensor product cell."""
+    if numpy.sum(ref_el.get_dimension()) == 1:
+        return UFCInterval()
+    elif numpy.sum(ref_el.get_dimension()) == 2:
+        return UFCQuadrilateral()
+    elif numpy.sum(ref_el.get_dimension()) == 3:
+        return UFCHexahedron()
+    else:
+        raise TypeError('Invalid cell type')
+
+
 def flatten_entities(topology_dict):
     """This function flattens topology dict of TensorProductCell and entity_dofs dict of TensorProductElement"""
 

--- a/FIAT/reference_element.py
+++ b/FIAT/reference_element.py
@@ -1033,6 +1033,7 @@ def is_hypercube(cell):
     else:
         return False
 
+
 def flatten_reference_cube(ref_el):
     """ ... """
     flattened_cube = {2: UFCQuadrilateral(), 3: UFCHexahedron()}

--- a/FIAT/reference_element.py
+++ b/FIAT/reference_element.py
@@ -1026,14 +1026,16 @@ def tuple_sum(tree):
 
 
 def is_hypercube(cell):
-    if isinstance(cell, TensorProductCell):
+    if isinstance(cell, (DefaultLine, UFCInterval, UFCQuadrilateral, UFCHexahedron)):
+        return True
+    elif isinstance(cell, TensorProductCell):
         return reduce(lambda a, b: a and b, [is_hypercube(c) for c in cell.cells])
     else:
-        return isinstance(cell, (DefaultLine, UFCInterval, UFCQuadrilateral, UFCHexahedron))
+        return False
 
 
 def flatten_reference_cube(ref_el):
-    """ ... """
+    """This function flattens a Tensor Product hypercube to the corresponding UFC hypercube"""
     flattened_cube = {2: UFCQuadrilateral(), 3: UFCHexahedron()}
     if numpy.sum(ref_el.get_dimension()) <= 1:
         # Just return point/interval cell arguments

--- a/FIAT/reference_element.py
+++ b/FIAT/reference_element.py
@@ -1025,16 +1025,27 @@ def tuple_sum(tree):
         return tree
 
 
-def flatten_reference_cube(ref_el):
-    """Returns a flattened cube corresponding to a given tensor product cell."""
-    if numpy.sum(ref_el.get_dimension()) <= 1:
-        return ref_el
-    elif numpy.sum(ref_el.get_dimension()) == 2 and len(ref_el.vertices) == 4:
-        return UFCQuadrilateral()
-    elif numpy.sum(ref_el.get_dimension()) == 3 and len(ref_el.vertices) == 8:
-        return UFCHexahedron()
+def is_hypercube(cell):
+    if isinstance(cell, (DefaultLine, UFCInterval, UFCQuadrilateral, UFCHexahedron)):
+        return True
+    elif isinstance(cell, TensorProductCell):
+        return reduce(lambda a, b: a and b, [is_hypercube(c) for c in cell.cells])
     else:
-        raise TypeError('Invalid cell type')
+        return False
+
+def flatten_reference_cube(ref_el):
+    """ ... """
+    flattened_cube = {2: UFCQuadrilateral(), 3: UFCHexahedron()}
+    if numpy.sum(ref_el.get_dimension()) <= 1:
+        # Just return point/interval cell arguments
+        return ref_el
+    else:
+        # Handle cases where cell is a quad/cube constructed from a tensor product or
+        # an already flattened element
+        if is_hypercube(ref_el):
+            return flattened_cube[numpy.sum(ref_el.get_dimension())]
+        else:
+            raise TypeError('Invalid cell type')
 
 
 def flatten_entities(topology_dict):

--- a/FIAT/serendipity.py
+++ b/FIAT/serendipity.py
@@ -165,14 +165,14 @@ class Serendipity(FiniteElement):
             alphas = mis(dim, o)
             for alpha in alphas:
                 try:
-                    poly = self.basis[alpha]
+                    polynomials = self.basis[alpha]
                 except KeyError:
-                    poly = diff(self.basis[(0,)*dim], *zip(variables, alpha))
-                    self.basis[alpha] = poly
-                T = np.zeros((len(poly), len(points)))
+                    polynomials = diff(self.basis[(0,)*dim], *zip(variables, alpha))
+                    self.basis[alpha] = polynomials
+                T = np.zeros((len(polynomials), len(points)))
                 for i in range(len(points)):
                     subs = {v: points[i][k] for k, v in enumerate(variables[:dim])}
-                    for j, f in enumerate(poly):
+                    for j, f in enumerate(polynomials):
                         T[j, i] = f.evalf(subs=subs)
                 phivals[alpha] = T
 

--- a/FIAT/serendipity.py
+++ b/FIAT/serendipity.py
@@ -56,7 +56,6 @@ class Serendipity(FiniteElement):
         dim = flat_el.get_spatial_dimension()
         flat_topology = flat_el.get_topology()
 
-        x, y, z = symbols('x y z')
         verts = flat_el.get_vertices()
 
         dx = ((verts[-1][0] - x)/(verts[-1][0] - verts[0][0]), (x - verts[0][0])/(verts[-1][0] - verts[0][0]))

--- a/FIAT/serendipity.py
+++ b/FIAT/serendipity.py
@@ -193,12 +193,12 @@ def v_lambda_0(dim, dx, dy, dz):
 def e_lambda_0(i, dim, dx, dy, dz, x_mid, y_mid, z_mid):
 
     if dim == 2:
-        EL = tuple([-leg(j, y_mid) * dy[0] * dy[1] * a for a in dx for j in range(i-1)] +
-                   [-leg(j, x_mid) * dx[0] * dx[1] * b for b in dy for j in range(i-1)])
+        EL = tuple([-leg(j, y_mid) * dy[0] * dy[1] * a for a in dx for j in range(i-1)]
+                   + [-leg(j, x_mid) * dx[0] * dx[1] * b for b in dy for j in range(i-1)])
     else:
-        EL = tuple([-leg(j, x_mid) * dx[0] * dx[1] * b * c for b in dy for c in dz for j in range(i-1)] +
-                   [-leg(j, y_mid) * dy[0] * dy[1] * a * c for c in dz for a in dx for j in range(i-1)] +
-                   [-leg(j, z_mid) * dz[0] * dz[1] * a * b for a in dx for b in dy for j in range(i-1)])
+        EL = tuple([-leg(j, x_mid) * dx[0] * dx[1] * b * c for b in dy for c in dz for j in range(i-1)]
+                   + [-leg(j, y_mid) * dy[0] * dy[1] * a * c for c in dz for a in dx for j in range(i-1)]
+                   + [-leg(j, z_mid) * dz[0] * dz[1] * a * b for a in dx for b in dy for j in range(i-1)])
 
     return EL
 
@@ -210,11 +210,11 @@ def f_lambda_0(i, dim, dx, dy, dz, x_mid, y_mid, z_mid):
                     for k in range(4, i + 1) for j in range(k-3)])
     else:
         FL = tuple([leg(j, x_mid) * leg(k-4-j, y_mid) * dx[0] * dx[1] * dy[0] * dy[1] * c
-                    for k in range(4, i + 1) for j in range(i-3) for c in dz] +
-                   [leg(j, z_mid) * leg(k-4-j, x_mid) * dx[0] * dx[1] * dz[0] * dz[1] * b
-                    for k in range(4, i + 1) for j in range(i-3) for b in dy] +
-                   [leg(j, y_mid) * leg(k-4-j, z_mid) * dy[0] * dy[1] * dz[0] * dz[1] * a
-                    for k in range(4, i + 1) for j in range(i-3) for a in dx])
+                    for k in range(4, i + 1) for j in range(i-3) for c in dz]
+                   + [leg(j, z_mid) * leg(k-4-j, x_mid) * dx[0] * dx[1] * dz[0] * dz[1] * b
+                      for k in range(4, i + 1) for j in range(i-3) for b in dy]
+                   + [leg(j, y_mid) * leg(k-4-j, z_mid) * dy[0] * dy[1] * dz[0] * dz[1] * a
+                      for k in range(4, i + 1) for j in range(i-3) for a in dx])
 
     return FL
 
@@ -223,8 +223,8 @@ def i_lambda_0(i, dx, dy, dz, x_mid, y_mid, z_mid):
 
     assert i >= 6, 'invalid value for i'
 
-    IL = tuple([-leg(l-6-j, x_mid) * leg(j-k, y_mid) * leg(k, z_mid) *
-                dx[0] * dx[1] * dy[0] * dy[1] * dz[0] * dz[1]
+    IL = tuple([-leg(l-6-j, x_mid) * leg(j-k, y_mid) * leg(k, z_mid)
+                * dx[0] * dx[1] * dy[0] * dy[1] * dz[0] * dz[1]
                 for l in range(6, i + 1) for j in range(i-5) for k in range(j+1)])
 
     return IL

--- a/FIAT/serendipity.py
+++ b/FIAT/serendipity.py
@@ -23,8 +23,8 @@ from FIAT.finite_element import FiniteElement
 from FIAT.lagrange import Lagrange
 from FIAT.dual_set import make_entity_closure_ids
 from FIAT.polynomial_set import mis
-from FIAT.discontinuous_pc import flatten_reference_element
-from FIAT.reference_element import compute_unflattening_map
+from FIAT.reference_element import (compute_unflattening_map,
+                                    flatten_reference_element)
 
 x, y, z = symbols('x y z')
 variables = (x, y, z)

--- a/FIAT/serendipity.py
+++ b/FIAT/serendipity.py
@@ -23,6 +23,8 @@ from FIAT.finite_element import FiniteElement
 from FIAT.lagrange import Lagrange
 from FIAT.dual_set import make_entity_closure_ids
 from FIAT.polynomial_set import mis
+from FIAT.discontinuous_pc import flatten_reference_element
+from FIAT.reference_element import compute_unflattening_map
 
 x, y, z = symbols('x y z')
 variables = (x, y, z)
@@ -50,11 +52,12 @@ class Serendipity(FiniteElement):
 
     def __init__(self, ref_el, degree):
 
-        dim = ref_el.get_spatial_dimension()
-        topology = ref_el.get_topology()
+        flat_el = flatten_reference_element(ref_el)
+        dim = flat_el.get_spatial_dimension()
+        flat_topology = flat_el.get_topology()
 
         x, y, z = symbols('x y z')
-        verts = ref_el.get_vertices()
+        verts = flat_el.get_vertices()
 
         dx = ((verts[-1][0] - x)/(verts[-1][0] - verts[0][0]), (x - verts[0][0])/(verts[-1][0] - verts[0][0]))
         dy = ((verts[-1][1] - y)/(verts[-1][1] - verts[0][1]), (y - verts[0][1])/(verts[-1][1] - verts[0][1]))
@@ -75,24 +78,24 @@ class Serendipity(FiniteElement):
         entity_ids = {}
         cur = 0
 
-        for top_dim, entities in topology.items():
+        for top_dim, entities in flat_topology.items():
             entity_ids[top_dim] = {}
             for entity in entities:
                 entity_ids[top_dim][entity] = []
 
-        for j in sorted(topology[0]):
+        for j in sorted(flat_topology[0]):
             entity_ids[0][j] = [cur]
             cur = cur + 1
 
         EL += e_lambda_0(degree, dim, dx, dy, dz, x_mid, y_mid, z_mid)
 
-        for j in sorted(topology[1]):
+        for j in sorted(flat_topology[1]):
             entity_ids[1][j] = list(range(cur, cur + degree - 1))
             cur = cur + degree - 1
 
         FL += f_lambda_0(degree, dim, dx, dy, dz, x_mid, y_mid, z_mid)
 
-        for j in sorted(topology[2]):
+        for j in sorted(flat_topology[2]):
             entity_ids[2][j] = list(range(cur, cur + tr(degree)))
             cur = cur + tr(degree)
 
@@ -110,9 +113,26 @@ class Serendipity(FiniteElement):
         super(Serendipity, self).__init__(ref_el=ref_el, dual=None, order=degree, formdegree=formdegree)
 
         self.basis = {(0,)*dim: Array(s_list)}
-        self.entity_ids = entity_ids
-        self.entity_closure_ids = make_entity_closure_ids(ref_el, entity_ids)
+
+        topology = ref_el.get_topology()
+        unflattening_map = compute_unflattening_map(topology)
+        unflattened_entity_ids = {}
+        unflattened_entity_closure_ids = {}
+
+        entity_closure_ids = make_entity_closure_ids(flat_el, entity_ids)
+
+        for dim, entities in sorted(topology.items()):
+            unflattened_entity_ids[dim] = {}
+            unflattened_entity_closure_ids[dim] = {}
+        for dim, entities in sorted(flat_topology.items()):
+            for entity in entities:
+                unflat_dim, unflat_entity = unflattening_map[(dim, entity)]
+                unflattened_entity_ids[unflat_dim][unflat_entity] = entity_ids[dim][entity]
+                unflattened_entity_closure_ids[unflat_dim][unflat_entity] = entity_closure_ids[dim][entity]
+        self.entity_ids = unflattened_entity_ids
+        self.entity_closure_ids = unflattened_entity_closure_ids
         self._degree = degree
+        self.flat_el = flat_el
 
     def degree(self):
         return self._degree + 1
@@ -136,7 +156,7 @@ class Serendipity(FiniteElement):
         points = list(map(transform, points))
 
         phivals = {}
-        dim = self.ref_el.get_spatial_dimension()
+        dim = self.flat_el.get_spatial_dimension()
         if dim <= 1:
             raise NotImplementedError('no tabulate method for serendipity elements of dimension 1 or less.')
         if dim >= 4:
@@ -178,7 +198,7 @@ class Serendipity(FiniteElement):
         raise NotImplementedError
 
     def space_dimension(self):
-        return len(self.basis[(0,)*self.ref_el.get_spatial_dimension()])
+        return len(self.basis[(0,)*self.flat_el.get_spatial_dimension()])
 
 
 def v_lambda_0(dim, dx, dy, dz):
@@ -197,9 +217,9 @@ def e_lambda_0(i, dim, dx, dy, dz, x_mid, y_mid, z_mid):
         EL = tuple([-leg(j, y_mid) * dy[0] * dy[1] * a for a in dx for j in range(i-1)]
                    + [-leg(j, x_mid) * dx[0] * dx[1] * b for b in dy for j in range(i-1)])
     else:
-        EL = tuple([-leg(j, x_mid) * dx[0] * dx[1] * b * c for b in dy for c in dz for j in range(i-1)]
-                   + [-leg(j, y_mid) * dy[0] * dy[1] * a * c for c in dz for a in dx for j in range(i-1)]
-                   + [-leg(j, z_mid) * dz[0] * dz[1] * a * b for a in dx for b in dy for j in range(i-1)])
+        EL = tuple([-leg(j, z_mid) * dz[0] * dz[1] * a * b for b in dx for a in dy for j in range(i-1)]
+                   + [-leg(j, y_mid) * dy[0] * dy[1] * a * c for a in dx for c in dz for j in range(i-1)]
+                   + [-leg(j, x_mid) * dx[0] * dx[1] * b * c for c in dy for b in dz for j in range(i-1)])
 
     return EL
 
@@ -210,12 +230,12 @@ def f_lambda_0(i, dim, dx, dy, dz, x_mid, y_mid, z_mid):
         FL = tuple([leg(j, x_mid) * leg(k-4-j, y_mid) * dx[0] * dx[1] * dy[0] * dy[1]
                     for k in range(4, i + 1) for j in range(k-3)])
     else:
-        FL = tuple([leg(j, x_mid) * leg(k-4-j, y_mid) * dx[0] * dx[1] * dy[0] * dy[1] * c
-                    for k in range(4, i + 1) for j in range(k-3) for c in dz]
+        FL = tuple([leg(j, y_mid) * leg(k-4-j, z_mid) * dy[0] * dy[1] * dz[0] * dz[1] * a
+                    for a in dx for k in range(4, i + 1) for j in range(k-3)]
                    + [leg(j, z_mid) * leg(k-4-j, x_mid) * dx[0] * dx[1] * dz[0] * dz[1] * b
-                      for k in range(4, i + 1) for j in range(k-3) for b in dy]
-                   + [leg(j, y_mid) * leg(k-4-j, z_mid) * dy[0] * dy[1] * dz[0] * dz[1] * a
-                      for k in range(4, i + 1) for j in range(k-3) for a in dx])
+                      for b in dy for k in range(4, i + 1) for j in range(k-3)]
+                   + [leg(j, x_mid) * leg(k-4-j, y_mid) * dx[0] * dx[1] * dy[0] * dy[1] * c
+                      for c in dz for k in range(4, i + 1) for j in range(k-3)])
 
     return FL
 

--- a/FIAT/serendipity.py
+++ b/FIAT/serendipity.py
@@ -24,7 +24,7 @@ from FIAT.lagrange import Lagrange
 from FIAT.dual_set import make_entity_closure_ids
 from FIAT.polynomial_set import mis
 from FIAT.reference_element import (compute_unflattening_map,
-                                    flatten_reference_element)
+                                    flatten_reference_cube)
 
 x, y, z = symbols('x y z')
 variables = (x, y, z)
@@ -52,7 +52,7 @@ class Serendipity(FiniteElement):
 
     def __init__(self, ref_el, degree):
 
-        flat_el = flatten_reference_element(ref_el)
+        flat_el = flatten_reference_cube(ref_el)
         dim = flat_el.get_spatial_dimension()
         flat_topology = flat_el.get_topology()
 

--- a/FIAT/serendipity.py
+++ b/FIAT/serendipity.py
@@ -101,6 +101,7 @@ class Serendipity(FiniteElement):
 
             entity_ids[3] = {}
             entity_ids[3][0] = list(range(cur, cur + len(IL)))
+            cur = cur + len(IL)
 
         s_list = VL + EL + FL + IL
         assert len(s_list) == cur
@@ -210,21 +211,19 @@ def f_lambda_0(i, dim, dx, dy, dz, x_mid, y_mid, z_mid):
                     for k in range(4, i + 1) for j in range(k-3)])
     else:
         FL = tuple([leg(j, x_mid) * leg(k-4-j, y_mid) * dx[0] * dx[1] * dy[0] * dy[1] * c
-                    for k in range(4, i + 1) for j in range(i-3) for c in dz]
+                    for k in range(4, i + 1) for j in range(k-3) for c in dz]
                    + [leg(j, z_mid) * leg(k-4-j, x_mid) * dx[0] * dx[1] * dz[0] * dz[1] * b
-                      for k in range(4, i + 1) for j in range(i-3) for b in dy]
+                      for k in range(4, i + 1) for j in range(k-3) for b in dy]
                    + [leg(j, y_mid) * leg(k-4-j, z_mid) * dy[0] * dy[1] * dz[0] * dz[1] * a
-                      for k in range(4, i + 1) for j in range(i-3) for a in dx])
+                      for k in range(4, i + 1) for j in range(k-3) for a in dx])
 
     return FL
 
 
 def i_lambda_0(i, dx, dy, dz, x_mid, y_mid, z_mid):
 
-    assert i >= 6, 'invalid value for i'
-
     IL = tuple([-leg(l-6-j, x_mid) * leg(j-k, y_mid) * leg(k, z_mid)
                 * dx[0] * dx[1] * dy[0] * dy[1] * dz[0] * dz[1]
-                for l in range(6, i + 1) for j in range(i-5) for k in range(j+1)])
+                for l in range(6, i + 1) for j in range(l-5) for k in range(j+1)])
 
     return IL

--- a/FIAT/serendipity.py
+++ b/FIAT/serendipity.py
@@ -214,12 +214,12 @@ def v_lambda_0(dim, dx, dy, dz):
 def e_lambda_0(i, dim, dx, dy, dz, x_mid, y_mid, z_mid):
 
     if dim == 2:
-        EL = tuple([-leg(j, y_mid) * dy[0] * dy[1] * a for a in dx for j in range(i-1)]
-                   + [-leg(j, x_mid) * dx[0] * dx[1] * b for b in dy for j in range(i-1)])
+        EL = tuple([-leg(j, y_mid) * dy[0] * dy[1] * a for a in dx for j in range(i-1)] +
+                   [-leg(j, x_mid) * dx[0] * dx[1] * b for b in dy for j in range(i-1)])
     else:
-        EL = tuple([-leg(j, z_mid) * dz[0] * dz[1] * a * b for b in dx for a in dy for j in range(i-1)]
-                   + [-leg(j, y_mid) * dy[0] * dy[1] * a * c for a in dx for c in dz for j in range(i-1)]
-                   + [-leg(j, x_mid) * dx[0] * dx[1] * b * c for c in dy for b in dz for j in range(i-1)])
+        EL = tuple([-leg(j, z_mid) * dz[0] * dz[1] * a * b for b in dx for a in dy for j in range(i-1)] +
+                   [-leg(j, y_mid) * dy[0] * dy[1] * a * c for a in dx for c in dz for j in range(i-1)] +
+                   [-leg(j, x_mid) * dx[0] * dx[1] * b * c for c in dy for b in dz for j in range(i-1)])
 
     return EL
 
@@ -231,19 +231,19 @@ def f_lambda_0(i, dim, dx, dy, dz, x_mid, y_mid, z_mid):
                     for k in range(4, i + 1) for j in range(k-3)])
     else:
         FL = tuple([leg(j, y_mid) * leg(k-4-j, z_mid) * dy[0] * dy[1] * dz[0] * dz[1] * a
-                    for a in dx for k in range(4, i + 1) for j in range(k-3)]
-                   + [leg(j, z_mid) * leg(k-4-j, x_mid) * dx[0] * dx[1] * dz[0] * dz[1] * b
-                      for b in dy for k in range(4, i + 1) for j in range(k-3)]
-                   + [leg(j, x_mid) * leg(k-4-j, y_mid) * dx[0] * dx[1] * dy[0] * dy[1] * c
-                      for c in dz for k in range(4, i + 1) for j in range(k-3)])
+                    for a in dx for k in range(4, i + 1) for j in range(k-3)] +
+                   [leg(j, z_mid) * leg(k-4-j, x_mid) * dx[0] * dx[1] * dz[0] * dz[1] * b
+                    for b in dy for k in range(4, i + 1) for j in range(k-3)] +
+                   [leg(j, x_mid) * leg(k-4-j, y_mid) * dx[0] * dx[1] * dy[0] * dy[1] * c
+                    for c in dz for k in range(4, i + 1) for j in range(k-3)])
 
     return FL
 
 
 def i_lambda_0(i, dx, dy, dz, x_mid, y_mid, z_mid):
 
-    IL = tuple([-leg(l-6-j, x_mid) * leg(j-k, y_mid) * leg(k, z_mid)
-                * dx[0] * dx[1] * dy[0] * dy[1] * dz[0] * dz[1]
+    IL = tuple([-leg(l-6-j, x_mid) * leg(j-k, y_mid) * leg(k, z_mid) *
+                dx[0] * dx[1] * dy[0] * dy[1] * dz[0] * dz[1]
                 for l in range(6, i + 1) for j in range(l-5) for k in range(j+1)])
 
     return IL


### PR DESCRIPTION
Fixed the Serendipity and dPc elements on TPCs. A new function flatten_reference_element maps the TPC onto a UFC cell where the element is constructed. The entity dofs are then mapped back to the corresponding TPC numbering.