### PR TITLE
orientations: define entity_permutations for CG and DG elements

### DIFF
--- a/FIAT/P0.py
+++ b/FIAT/P0.py
@@ -18,6 +18,7 @@ class P0Dual(dual_set.DualSet):
     def __init__(self, ref_el):
         entity_ids = {}
         nodes = []
+        entity_permutations = {}
         vs = numpy.array(ref_el.get_vertices())
         if ref_el.get_dimension() == 0:
             bary = ()
@@ -29,12 +30,23 @@ class P0Dual(dual_set.DualSet):
         top = ref_el.get_topology()
         for dim in sorted(top):
             entity_ids[dim] = {}
+            entity_permutations[dim] = {}
+            sym_size = ref_el.symmetry_group_size(dim)
+            if isinstance(dim, tuple):
+                assert isinstance(sym_size, tuple)
+                perms = {o: [] for o in numpy.ndindex(sym_size)}
+            else:
+                perms = {o: [] for o in range(sym_size)}
             for entity in sorted(top[dim]):
                 entity_ids[dim][entity] = []
-
+                entity_permutations[dim][entity] = perms
         entity_ids[dim] = {0: [0]}
+        if isinstance(dim, tuple):
+            entity_permutations[dim][0] = {o: [0] for o in numpy.ndindex(sym_size)}
+        else:
+            entity_permutations[dim][0] = {o: [0] for o in range(sym_size)}
 
-        super(P0Dual, self).__init__(nodes, ref_el, entity_ids)
+        super(P0Dual, self).__init__(nodes, ref_el, entity_ids, entity_permutations)
 
 
 class P0(finite_element.CiarletElement):

--- a/FIAT/discontinuous_lagrange.py
+++ b/FIAT/discontinuous_lagrange.py
@@ -5,7 +5,138 @@
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
+import itertools
+import numpy as np
 from FIAT import finite_element, polynomial_set, dual_set, functional, P0
+from FIAT.polynomial_set import mis
+
+
+def make_entity_permutations(dim, npoints):
+    if npoints <= 0:
+        return {o: [] for o in range(np.math.factorial(dim + 1))}
+    # DG nodes are numbered, in order of significance,
+    # - by g0: entity dim (vertices first, then edges, then ...)
+    # - by g1: entity ids (DoFs on entities of smaller ids first)
+    # - lexicographically as in CG
+    #
+    # Example:
+    # dim = 2, degree = 3 (npoints = degree + 1)
+    #
+    #     facet ids     Lexicographic  DG (degree = 3)
+    #    +              DoF numbering  DoF numbering
+    #    | \            9              2
+    #    |   \  0       7 8            6 4
+    #  1 |     \        4 5 6          5 9 3
+    #    |       \      0 1 2 3        0 7 8 1
+    #    +--------+
+    #        2
+    # where DG degrees of freedom are numbered to geometrically
+    # coincide with CG degrees of freedom.
+    #
+    # In the below we will show example outputs corresponding to
+    # the above example.
+
+    a = np.array(sorted(mis(dim + 1, npoints - 1)), dtype=int)
+    # >>> a
+    # [[0, 0, 3],
+    #  [0, 1, 2],   # (3,0,0)
+    #  [0, 2, 1],   #
+    #  [0, 3, 0],   # (2,0,1)(2,1,0)
+    #  [1, 0, 2],   #
+    #  [1, 1, 1],   # (1,0,2)(1,1,1)(1,2,0)
+    #  [1, 2, 0],   #
+    #  [2, 0, 1],   # (0,0,3)(0,1,2)(0,2,1)(0,3,0)
+    #  [2, 1, 0],   #
+    #  [3, 0, 0]]   # Lattice points that a represents
+    # a.shape[0] = number of DoFs
+    # a.shape[1] = dim + 1
+    # sum of each row = degree (bary centric lattice coordinates)
+
+    # Flip along the axis 1 for convenience.
+    # This would make: np.lexsort(a.transpose()) = [0, 1, 2, ..., 9].
+    a = a[:, ::-1]
+
+    index_perms = sorted(itertools.permutations(range(dim + 1)))
+    # >>> index_perms
+    # [[0, 1, 2],
+    #  [0, 2, 1],
+    #  [1, 0, 2],
+    #  [1, 2, 0],
+    #  [2, 0, 1],
+    #  [2, 1, 0]]
+
+    # First separate by entity dimension.
+    g0 = dim - (a == 0).astype(int).sum(axis=1)
+    # >>> g0
+    # [ 0, 1, 1, 0, 1, 2, 1, 1, 1, 0]  # 0 for vertices
+    #                                  # 1 for edges
+    #                                  # 2 for cell
+
+    # Then separate by entity number.
+    g1 = np.zeros_like(g0)
+    for d in range(dim + 1):
+        on_facet_d = (a[:, d] == 0).astype(int)
+        g1 += d * on_facet_d
+    # The above logic is consistent with the FIAT entity numbering
+    # convention ("entities that are not incident to vertex 0 are
+    # numbered first, then ..."), but vertices are not numbered using
+    # the same logic in FIAT, so we need to fix:
+    g1[g0 == 0] = -g1[g0 == 0]
+    # >>> g1
+    # [-3, 2, 2,-2, 1, 0, 0, 1, 0,-1]
+
+    # Compoute the map from the DG DoFs to the lattice points on the cell.
+    # For each entity dimension, DoFs that have smaller numbers in g1
+    # will be assigned smaller DG node numbers.
+    # Order first by g0, then by g1, and finally by a (lexicographically as in CG)
+    g0 = g0.reshape((a.shape[0], 1))
+    g1 = g1.reshape((a.shape[0], 1))
+    dg_to_lattice = np.lexsort(np.transpose(np.concatenate((a, g1, g0), axis=1)))
+    # >>> dg_to_lattice
+    # [ 0, 3, 9, 6, 8, 4, 7, 1, 2, 5]
+
+    # Compute the inverse map.
+    lattice_to_dg = np.empty_like(dg_to_lattice)
+    for i, im in enumerate(dg_to_lattice):
+        lattice_to_dg[im] = i
+    # >>> lattice_to_dg
+    # [ 0, 7, 8, 1, 5, 9, 3, 6, 4, 2]
+    perms = {}
+    for o, index_perm in enumerate(index_perms):
+        # First compute permutation in lattice point numbers in lattice point order (as we do for CG cell DoFs)
+        perm = np.lexsort(np.transpose(a[:, index_perm]))
+        # Then convert to DG DoF numbers in DG DoF order:
+        # lattice_to_dg[perm]                -> convert lattice point numbers to DG DoF numbers
+        # lattice_to_dg[perm][dg_to_lattice] -> reorder for DG DoF order
+        #
+        # Example:
+        # Under one CW rotation, a DG element on a physical cell
+        # is mapped to the FIAT reference as:
+        #
+        # 0
+        # 7 5
+        # 8 9 6
+        # 1 3 4 2
+        #
+        # Under the same transformation, the lattice points would
+        # be mapped as:
+        #
+        # 0
+        # 1 4
+        # 2 5 7
+        # 3 6 8 9
+        #
+        # In this case we will have:
+        #
+        # perm                               = [3, 6, 8, 9, 2, 5, 7, 1, 4, 0]
+        # lattice_to_dg[perm]                = [1, 3, 4, 2, 8, 9, 6, 7, 5, 0]
+        # lattice_to_dg[perm][dg_to_lattice] = [1, 2, 0, 6, 5, 8, 7, 3, 4, 9]
+        #
+        # Note:
+        # Sane thing to do is to just number DG dofs on a lattice.
+        perm = lattice_to_dg[perm][dg_to_lattice]
+        perms[o] = perm.tolist()
+    return perms
 
 
 class DiscontinuousLagrangeDualSet(dual_set.DualSet):
@@ -17,6 +148,7 @@ class DiscontinuousLagrangeDualSet(dual_set.DualSet):
     def __init__(self, ref_el, degree):
         entity_ids = {}
         nodes = []
+        entity_permutations = {}
 
         # make nodes by getting points
         # need to do this dimension-by-dimension, facet-by-facet
@@ -25,6 +157,8 @@ class DiscontinuousLagrangeDualSet(dual_set.DualSet):
         cur = 0
         for dim in sorted(top):
             entity_ids[dim] = {}
+            entity_permutations[dim] = {}
+            perms = make_entity_permutations(dim, degree + 1 if dim == len(top) - 1 else -1)
             for entity in sorted(top[dim]):
                 pts_cur = ref_el.make_points(dim, entity, degree)
                 nodes_cur = [functional.PointEvaluation(ref_el, x)
@@ -33,10 +167,10 @@ class DiscontinuousLagrangeDualSet(dual_set.DualSet):
                 nodes += nodes_cur
                 entity_ids[dim][entity] = []
                 cur += nnodes_cur
-
+                entity_permutations[dim][entity] = perms
         entity_ids[dim][0] = list(range(len(nodes)))
 
-        super(DiscontinuousLagrangeDualSet, self).__init__(nodes, ref_el, entity_ids)
+        super(DiscontinuousLagrangeDualSet, self).__init__(nodes, ref_el, entity_ids, entity_permutations)
 
 
 class HigherOrderDiscontinuousLagrange(finite_element.CiarletElement):

--- a/FIAT/dual_set.py
+++ b/FIAT/dual_set.py
@@ -13,10 +13,11 @@ from FIAT import polynomial_set
 
 
 class DualSet(object):
-    def __init__(self, nodes, ref_el, entity_ids):
+    def __init__(self, nodes, ref_el, entity_ids, entity_permutations=None):
         self.nodes = nodes
         self.ref_el = ref_el
         self.entity_ids = entity_ids
+        self.entity_permutations = entity_permutations
 
         # Compute the nodes on the closure of each sub_entity.
         self.entity_closure_ids = {}
@@ -39,6 +40,34 @@ class DualSet(object):
 
     def get_entity_ids(self):
         return self.entity_ids
+
+    def get_entity_permutations(self):
+        r"""This method returns a nested dictionary that gives, for
+        each dimension, for each entity, and for each possible entity
+        orientation, the DoF permutation array that maps the entity
+        local DoF ordering to the canonical global DoF ordering; see
+        :class:`~.Simplex` and :class:`~.UFCQuadrilateral` for how we
+        define entity orientations for standard cells.
+
+        The entity permutations `dict` for the degree 4 Lagrange finite
+        element on the interval, for instance, is given by:
+
+        .. code-block:: python3
+
+            {0: {0: {0: [0]},
+                 1: {0: [0]}},
+             1: {0: {0: [0, 1, 2],
+                     1: [2, 1, 0]}}}
+
+        Note that there are two entities on dimension ``0`` (vertices),
+        each of which has only one possible orientation, while there is
+        a single entity on dimension ``1`` (interval), which has two
+        possible orientations representing non-reflected and reflected
+        intervals.
+        """
+        if self.entity_permutations is None:
+            raise NotImplementedError("entity_permutations not yet implemented for %s" % type(self))
+        return self.entity_permutations
 
     def get_reference_element(self):
         return self.ref_el

--- a/FIAT/finite_element.py
+++ b/FIAT/finite_element.py
@@ -12,6 +12,7 @@ import numpy
 
 from FIAT.polynomial_set import PolynomialSet
 from FIAT.quadrature_schemes import create_quadrature
+from FIAT.dual_set import DualSet
 
 
 class FiniteElement(object):
@@ -59,6 +60,11 @@ class FiniteElement(object):
         """Return the map of topological entities to degrees of
         freedom on the closure of those entities for the finite element."""
         return self.dual.get_entity_closure_ids()
+
+    def entity_permutations(self):
+        return self.dual.get_entity_permutations()
+
+    entity_permutations.__doc__ = DualSet.get_entity_permutations.__doc__
 
     def get_formdegree(self):
         """Return the degree of the associated form (FEEC)"""

--- a/FIAT/gauss_legendre.py
+++ b/FIAT/gauss_legendre.py
@@ -13,6 +13,7 @@ import numpy
 from FIAT import finite_element, polynomial_set, dual_set, functional, quadrature
 from FIAT.reference_element import LINE
 from FIAT.barycentric_interpolation import barycentric_interpolation
+from FIAT.lagrange import make_entity_permutations
 
 
 class GaussLegendreDualSet(dual_set.DualSet):
@@ -23,8 +24,11 @@ class GaussLegendreDualSet(dual_set.DualSet):
                       1: {0: list(range(0, degree+1))}}
         lr = quadrature.GaussLegendreQuadratureLineRule(ref_el, degree+1)
         nodes = [functional.PointEvaluation(ref_el, x) for x in lr.pts]
+        entity_permutations = {}
+        entity_permutations[0] = {0: {0: []}, 1: {0: []}}
+        entity_permutations[1] = {0: make_entity_permutations(1, degree + 1)}
 
-        super(GaussLegendreDualSet, self).__init__(nodes, ref_el, entity_ids)
+        super(GaussLegendreDualSet, self).__init__(nodes, ref_el, entity_ids, entity_permutations)
 
 
 class GaussLegendre(finite_element.CiarletElement):

--- a/FIAT/gauss_lobatto_legendre.py
+++ b/FIAT/gauss_lobatto_legendre.py
@@ -13,6 +13,7 @@ import numpy
 from FIAT import finite_element, polynomial_set, dual_set, functional, quadrature
 from FIAT.reference_element import LINE
 from FIAT.barycentric_interpolation import barycentric_interpolation
+from FIAT.lagrange import make_entity_permutations
 
 
 class GaussLobattoLegendreDualSet(dual_set.DualSet):
@@ -23,8 +24,11 @@ class GaussLobattoLegendreDualSet(dual_set.DualSet):
                       1: {0: list(range(1, degree))}}
         lr = quadrature.GaussLobattoLegendreQuadratureLineRule(ref_el, degree+1)
         nodes = [functional.PointEvaluation(ref_el, x) for x in lr.pts]
+        entity_permutations = {}
+        entity_permutations[0] = {0: {0: [0]}, 1: {0: [0]}}
+        entity_permutations[1] = {0: make_entity_permutations(1, degree - 1)}
 
-        super(GaussLobattoLegendreDualSet, self).__init__(nodes, ref_el, entity_ids)
+        super(GaussLobattoLegendreDualSet, self).__init__(nodes, ref_el, entity_ids, entity_permutations)
 
 
 class GaussLobattoLegendre(finite_element.CiarletElement):

--- a/FIAT/lagrange.py
+++ b/FIAT/lagrange.py
@@ -5,7 +5,68 @@
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
+import itertools
+import numpy as np
 from FIAT import finite_element, polynomial_set, dual_set, functional
+from FIAT.polynomial_set import mis
+
+
+def make_entity_permutations(dim, npoints):
+    r"""Make orientation-permutation map for the given
+    simplex dimension, dim, and the number of points along
+    each axis
+
+    As an example, we first compute the orientation of a
+    triangular cell:
+
+       +                    +
+       | \                  | \
+       1   0               47   42
+       |     \              |     \
+       +--2---+             +--43--+
+    FIAT canonical     Mapped example physical cell
+
+    Suppose that the facets of the physical cell
+    are canonically ordered as:
+
+    C = [43, 42, 47]
+
+    FIAT facet to Physical facet map is given by:
+
+    M = [42, 47, 43]
+
+    Then the orientation of the cell is computed as:
+
+    C.index(M[0]) = 1; C.remove(M[0])
+    C.index(M[1]) = 1; C.remove(M[1])
+    C.index(M[2]) = 0; C.remove(M[2])
+
+    o = (1 * 2!) + (1 * 1!) + (0 * 0!) = 3
+
+    For npoints = 3, there are 6 DoFs:
+
+        5                   0
+        3 4                 1 3
+        0 1 2               2 4 5
+    FIAT canonical     Physical cell canonical
+
+    The permutation associated with o = 3 then is:
+
+    [2, 4, 5, 1, 3, 0]
+
+    The output of this function contains one such permutation
+    for each orientation for the given simplex dimension and
+    the number of points along each axis.
+    """
+    if npoints <= 0:
+        return {o: [] for o in range(np.math.factorial(dim + 1))}
+    a = np.array(sorted(mis(dim + 1, npoints - 1)), dtype=int)[:, ::-1]
+    index_perms = sorted(itertools.permutations(range(dim + 1)))
+    perms = {}
+    for o, index_perm in enumerate(index_perms):
+        perm = np.lexsort(np.transpose(a[:, index_perm]))
+        perms[o] = perm.tolist()
+    return perms
 
 
 class LagrangeDualSet(dual_set.DualSet):
@@ -16,6 +77,7 @@ class LagrangeDualSet(dual_set.DualSet):
     def __init__(self, ref_el, degree):
         entity_ids = {}
         nodes = []
+        entity_permutations = {}
 
         # make nodes by getting points
         # need to do this dimension-by-dimension, facet-by-facet
@@ -24,6 +86,8 @@ class LagrangeDualSet(dual_set.DualSet):
         cur = 0
         for dim in sorted(top):
             entity_ids[dim] = {}
+            entity_permutations[dim] = {}
+            perms = {0: [0]} if dim == 0 else make_entity_permutations(dim, degree - dim)
             for entity in sorted(top[dim]):
                 pts_cur = ref_el.make_points(dim, entity, degree)
                 nodes_cur = [functional.PointEvaluation(ref_el, x)
@@ -32,8 +96,9 @@ class LagrangeDualSet(dual_set.DualSet):
                 nodes += nodes_cur
                 entity_ids[dim][entity] = list(range(cur, cur + nnodes_cur))
                 cur += nnodes_cur
+                entity_permutations[dim][entity] = perms
 
-        super(LagrangeDualSet, self).__init__(nodes, ref_el, entity_ids)
+        super(LagrangeDualSet, self).__init__(nodes, ref_el, entity_ids, entity_permutations)
 
 
 class Lagrange(finite_element.CiarletElement):

--- a/FIAT/reference_element.py
+++ b/FIAT/reference_element.py
@@ -223,10 +223,46 @@ class Cell(object):
         """
         raise NotImplementedError("Should be implemented in a subclass.")
 
+    def symmetry_group_size(self, dim):
+        """Returns the size of the symmetry group of an entity of
+        dimension `dim`."""
+        raise NotImplementedError("Should be implemented in a subclass.")
+
 
 class Simplex(Cell):
-    """Abstract class for a reference simplex."""
+    r"""Abstract class for a reference simplex.
 
+    Orientation of a physical cell is computed systematically
+    by comparing the canonical orderings of its facets and
+    the facets in the FIAT reference cell.
+
+    As an example, we compute the orientation of a
+    triangular cell:
+
+       +                    +
+       | \                  | \
+       1   0               47   42
+       |     \              |     \
+       +--2---+             +--43--+
+    FIAT canonical     Mapped example physical cell
+
+    Suppose that the facets of the physical cell
+    are canonically ordered as:
+
+    C = [43, 42, 47]
+
+    FIAT facet to Physical facet map is given by:
+
+    M = [42, 47, 43]
+
+    Then the orientation of the cell is computed as:
+
+    C.index(M[0]) = 1; C.remove(M[0])
+    C.index(M[1]) = 1; C.remove(M[1])
+    C.index(M[2]) = 0; C.remove(M[2])
+
+    o = (1 * 2!) + (1 * 1!) + (0 * 0!) = 3
+    """
     def compute_normal(self, facet_i):
         """Returns the unit normal vector to facet i of codimension 1."""
         # Interval case
@@ -446,6 +482,9 @@ class Simplex(Cell):
         """Returns the subelement dimension of the cell.  Same as the
         spatial dimension."""
         return self.get_spatial_dimension()
+
+    def symmetry_group_size(self, dim):
+        return numpy.math.factorial(dim + 1)
 
 
 # Backwards compatible name
@@ -770,11 +809,55 @@ class TensorProductCell(Cell):
                        for c, s in zip(self.cells, slices)),
                       True)
 
+    def symmetry_group_size(self, dim):
+        return tuple(c.symmetry_group_size(d) for d, c in zip(dim, self.cells))
+
 
 class UFCQuadrilateral(Cell):
-    """This is the reference quadrilateral with vertices
-    (0.0, 0.0), (0.0, 1.0), (1.0, 0.0) and (1.0, 1.0)."""
+    r"""This is the reference quadrilateral with vertices
+    (0.0, 0.0), (0.0, 1.0), (1.0, 0.0) and (1.0, 1.0).
 
+    Orientation of a physical cell is computed systematically
+    by comparing the canonical orderings of its facets and
+    the facets in the FIAT reference cell.
+
+    As an example, we compute the orientation of a
+    quadrilateral cell:
+
+       +---3---+           +--57---+
+       |       |           |       |
+       0       1          43       55
+       |       |           |       |
+       +---2---+           +--42---+
+    FIAT canonical     Mapped example physical cell
+
+    Suppose that the facets of the physical cell
+    are canonically ordered as:
+
+    C = [55, 42, 43, 57]
+
+    FIAT index to Physical index map must be such that
+    C[0] = 55 is mapped to a vertical facet; in this
+    example it is:
+
+    M = [43, 55, 42, 57]
+
+    C and M are decomposed into "vertical" and "horizontal"
+    parts, keeping the relative orders of numbers:
+
+    C -> C0 = [55, 43], C1 = [42, 57]
+    M -> M0 = [43, 55], M1 = [42, 57]
+
+    Then the orientation of the cell is computed as the
+    following:
+
+    C0.index(M0[0]) = 1; C0.remove(M0[0])
+    C0.index(M0[1]) = 0; C0.remove(M0[1])
+    C1.index(M1[0]) = 0; C1.remove(M1[0])
+    C1.index(M1[1]) = 0; C1.remove(M1[1])
+
+    o = 2 * 1 + 0 = 2
+    """
     def __init__(self):
         product = TensorProductCell(UFCInterval(), UFCInterval())
         pt = product.get_topology()
@@ -831,6 +914,9 @@ class UFCQuadrilateral(Cell):
         """Checks if reference cell contains given point
         (with numerical tolerance)."""
         return self.product.contains_point(point, epsilon=epsilon)
+
+    def symmetry_group_size(self, dim):
+        return [1, 2, 8][dim]
 
 
 class UFCHexahedron(Cell):
@@ -896,6 +982,9 @@ class UFCHexahedron(Cell):
         """Checks if reference cell contains given point
         (with numerical tolerance)."""
         return self.product.contains_point(point, epsilon=epsilon)
+
+    def symmetry_group_size(self, dim):
+        return [1, 2, 8, 48][dim]
 
 
 def make_affine_mapping(xs, ys):
@@ -1060,6 +1149,18 @@ def flatten_entities(topology_dict):
 
     return {dim: dict(enumerate(entities))
             for dim, entities in flattened_entities.items()}
+
+
+def flatten_permutations(perm_dict):
+    """This function flattens permutation dict of TensorProductElement"""
+
+    flattened_permutations = defaultdict(list)
+    for dim in sorted(perm_dict.keys()):
+        flat_dim = tuple_sum(dim)
+        flattened_permutations[flat_dim] += [{o: v[o_tuple] for o, o_tuple in enumerate(sorted(v))}
+                                             for k, v in sorted(perm_dict[dim].items())]
+    return {dim: dict(enumerate(perms))
+            for dim, perms in flattened_permutations.items()}
 
 
 def compute_unflattening_map(topology_dict):


### PR DESCRIPTION
This PR is to attach `entity_permutations` `dict` to basic finite elements (such as `Lagrange`) that defines a DoF permutation (to be used in global vector assembly) for each possible entity orientation for each entity for each dimension. 
`entity_permutations` is set `None` if it is not yet implemented for that element, so the problem solving environment must handle this correctly if it ever tries to access this attribute.

This is intended to be the first step for FIAT to handle orientations.