### PR TITLE
Turn off randomisation of the test domains of the AWc, AWnc, and MTW elements.

### DIFF
--- a/test/unit/test_awc.py
+++ b/test/unit/test_awc.py
@@ -5,7 +5,7 @@ from FIAT import ufc_simplex, ArnoldWinther, make_quadrature, expansions
 def test_dofs():
     line = ufc_simplex(1)
     T = ufc_simplex(2)
-    T.vertices = np.random.rand(3, 2)
+    T.vertices = np.asarray([(0.0, 0.0), (1.0, 0.25), (-0.75, 1.1)])
     AW = ArnoldWinther(T, 3)
 
     # check Kronecker property at vertices

--- a/test/unit/test_awnc.py
+++ b/test/unit/test_awnc.py
@@ -5,7 +5,7 @@ from FIAT import ufc_simplex, ArnoldWintherNC, make_quadrature, expansions
 def test_dofs():
     line = ufc_simplex(1)
     T = ufc_simplex(2)
-    T.vertices = np.random.rand(3, 2)
+    T.vertices = np.asarray([(0.0, 0.0), (1.0, 0.25), (-0.75, 1.1)])
     AW = ArnoldWintherNC(T, 2)
 
     Qline = make_quadrature(line, 6)

--- a/test/unit/test_mtw.py
+++ b/test/unit/test_mtw.py
@@ -5,7 +5,7 @@ from FIAT import ufc_simplex, MardalTaiWinther, make_quadrature, expansions
 def test_dofs():
     line = ufc_simplex(1)
     T = ufc_simplex(2)
-    T.vertices = np.random.rand(3, 2)
+    T.vertices = np.asarray([(0.0, 0.0), (1.0, 0.25), (-0.75, 1.1)])
     MTW = MardalTaiWinther(T, 3)
 
     Qline = make_quadrature(line, 6)


### PR DESCRIPTION
As per the Slack discussion on 13th Jan '22, change the domains of the tests of the zany AWc, AWnc, and MTW elements from a random triangle to (as suggested by @rckirby) a fixed rotation and shear of the unit triangle, to avoid the error encountered by @pbrubeck. Note that in `test_awc.py`, the domains of `test_dofs` and `test_projection` are (still) different.