### PR TITLE
Ksagiyam/fix serendipity

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,7 @@
 [flake8]
 ignore = E501,E226,E731,W504,
-         E741                   # ambiguous variable name
+         # ambiguous variable name
+         E741
 exclude = .git,__pycache__,doc/sphinx/source/conf.py,build,dist
 min-version = 3.0
 
@@ -8,7 +9,8 @@ min-version = 3.0
 # Work on removing these ignores
 ignore = D100,D101,D102,D103,D104,D105,D107,
          D200,D202,
-         D203,  # this error should be disabled
+         # this error should be disabled
+         D203,
          D204,D205,D208,D209,D212,D213,
 	 D300,
          D400,D401,D404,D412,D415,D416

--- a/test/unit/test_discontinuous_pc.py
+++ b/test/unit/test_discontinuous_pc.py
@@ -40,7 +40,7 @@ def test_basis_values(dim, degree):
 
     for test_degree in range(degree + 1):
         coefs = [n(lambda x: x[0]**test_degree) for n in fe.dual.nodes]
-        integral = np.float(np.dot(coefs, np.dot(tab, q.wts)))
+        integral = float(np.dot(coefs, np.dot(tab, q.wts)))
         reference = np.dot([x[0]**test_degree
                             for x in q.pts], q.wts)
         assert np.isclose(integral, reference, rtol=1e-14)

--- a/test/unit/test_discontinuous_taylor.py
+++ b/test/unit/test_discontinuous_taylor.py
@@ -38,7 +38,7 @@ def test_basis_values(dim, degree):
 
     for test_degree in range(degree + 1):
         coefs = [n(lambda x: x[0]**test_degree) for n in fe.dual.nodes]
-        integral = np.float(np.dot(coefs, np.dot(tab, q.wts)))
+        integral = float(np.dot(coefs, np.dot(tab, q.wts)))
         reference = np.dot([x[0]**test_degree
                             for x in q.pts], q.wts)
         assert np.isclose(integral, reference, rtol=1e-14)


### PR DESCRIPTION
With `numpy>=1.24.1`, we can no longer make a numpy array with objects of inhomogeneous shape (unless we specify `dtype=object` explicitly), which is used in `serendipity.py`;
The relevant Firedrake test fails with:
```
FAILED tests/regression/test_serendipity_biharmonic.py::test_serendipity_biharmonic - ValueError: setting an array element with a sequence. The requested array has an inhomogeneous shape after 1 dimensions. The detected shape was (8,) + inhomogeneous part.
```
(https://github.com/firedrakeproject/firedrake/actions/runs/3864507367).

In principle something like the following is happening:
```
from sympy import symbols, Array, lambdify
import numpy as np
import inspect


x = symbols('x')
expr = Array([0, x])
f = lambdify(x, expr, 'numpy')
print(inspect.getsource(f))
a = np.array([1, 2])
# Works as before if we could set `dtype=object`.
print(np.array((0, a), dtype=object))
# Fails with numpy>=1.24.1.
print(f(a))
```
where numpy array construction happens in a function (`f`) returned by `sympy`, and we are unable to specify `dtype=object`.

This PR attempts to fix this in some way.

Firedrake test: https://github.com/firedrakeproject/firedrake/pull/2716