### PR TITLE
Ensure EnrichedElement uses the embedding ExpansionSet

### DIFF
--- a/FIAT/barycentric_interpolation.py
+++ b/FIAT/barycentric_interpolation.py
@@ -29,19 +29,23 @@ class LagrangeLineExpansionSet(expansions.LineExpansionSet):
     https://doi.org/10.1137/S0036144502417715 Eq. (4.2) & (9.4)
     """
     def __init__(self, ref_el, pts):
-        self.nodes = numpy.array(pts).flatten()
-        self.dmat, self.weights = make_dmat(self.nodes)
+        self.points = pts
+        self.x = numpy.array(pts).flatten()
+        self.dmat, self.weights = make_dmat(self.x)
         super(LagrangeLineExpansionSet, self).__init__(ref_el)
 
     def get_num_members(self, n):
-        return len(self.nodes)
+        return len(self.points)
+
+    def get_points(self):
+        return self.points
 
     def get_dmats(self, degree):
         return [self.dmat.T]
 
     def tabulate(self, n, pts):
-        assert n == len(self.nodes)-1
-        results = numpy.add.outer(-self.nodes, numpy.array(pts).flatten())
+        assert n == len(self.points)-1
+        results = numpy.add.outer(-self.x, numpy.array(pts).flatten())
         with numpy.errstate(divide='ignore', invalid='ignore'):
             numpy.reciprocal(results, out=results)
             numpy.multiply(results, self.weights[:, None], out=results)

--- a/FIAT/barycentric_interpolation.py
+++ b/FIAT/barycentric_interpolation.py
@@ -85,14 +85,14 @@ class LagrangePolynomialSet(polynomial_set.PolynomialSet):
         if shape == tuple():
             coeffs = numpy.eye(num_members)
         else:
-            coeffs_shape = tuple([num_members] + list(shape) + [num_exp_functions])
+            coeffs_shape = (num_members, *shape, num_exp_functions)
             coeffs = numpy.zeros(coeffs_shape, "d")
             # use functional's index_iterator function
             cur_bf = 0
             for idx in index_iterator(shape):
                 n = expansions.polynomial_dimension(ref_el, embedded_degree)
                 for exp_bf in range(n):
-                    cur_idx = tuple([cur_bf] + list(idx) + [exp_bf])
+                    cur_idx = (cur_bf, *idx, exp_bf)
                     coeffs[cur_idx] = 1.0
                     cur_bf += 1
 

--- a/FIAT/expansions.py
+++ b/FIAT/expansions.py
@@ -9,7 +9,6 @@ to allow users to get coordinates that they want."""
 
 import numpy
 import math
-from itertools import product
 from FIAT import reference_element
 from FIAT import jacobi
 
@@ -215,7 +214,7 @@ class ExpansionSet(object):
         result = {(0,) * D: numpy.array(vals[0])}
         for r in range(1, 1+lorder):
             vr = numpy.transpose(vals[r], tuple(range(1, r+1)) + (0, r+1))
-            for indices in product(range(D), repeat=r):
+            for indices in numpy.ndindex(vr.shape[:r]):
                 alpha = tuple(map(indices.count, range(D)))
                 if alpha not in result:
                     result[alpha] = vr[indices]
@@ -258,10 +257,10 @@ class ExpansionSet(object):
         v0 = vals[(0,)*D]
         data = [v0]
         for r in range(1, order+1):
-            v = numpy.zeros((D,)*r + v0.shape, dtype=v0.dtype)
-            for index in product(range(D), repeat=r):
-                v[index] = vals[tuple(map(index.count, range(D)))]
-            data.append(v.transpose((r, r+1) + tuple(range(r))))
+            vr = numpy.zeros((D,)*r + v0.shape, dtype=v0.dtype)
+            for index in numpy.ndindex(vr.shape[:r]):
+                vr[index] = vals[tuple(map(index.count, range(D)))]
+            data.append(vr.transpose((r, r+1) + tuple(range(r))))
         return data
 
 

--- a/FIAT/expansions.py
+++ b/FIAT/expansions.py
@@ -209,19 +209,16 @@ class ExpansionSet(object):
 
     def _tabulate_jet(self, degree, pts, order=0):
         from FIAT.polynomial_set import mis
-        result = {}
         D = self.ref_el.get_spatial_dimension()
         lorder = min(2, order)
         vals = self._tabulate(degree, numpy.transpose(pts), order=lorder)
-        base_vals = numpy.array(vals[0])
-        base_alpha = (0,) * D
-        result[base_alpha] = base_vals
+        result = {(0,) * D: numpy.array(vals[0])}
         for r in range(1, 1+lorder):
             vr = numpy.transpose(vals[r], tuple(range(1, r+1)) + (0, r+1))
             for indices in product(range(D), repeat=r):
                 alpha = tuple(map(indices.count, range(D)))
                 if alpha not in result:
-                    result[alpha] = vr[indices].reshape(base_vals.shape)
+                    result[alpha] = vr[indices]
 
         def distance(alpha, beta):
             return sum(ai != bi for ai, bi in zip(alpha, beta))

--- a/FIAT/lagrange.py
+++ b/FIAT/lagrange.py
@@ -48,7 +48,7 @@ class Lagrange(finite_element.CiarletElement):
 
     def __init__(self, ref_el, degree, variant="equispaced"):
         dual = LagrangeDualSet(ref_el, degree, variant=variant)
-        if ref_el.shape == LINE and variant != "equispaced":
+        if ref_el.shape == LINE:
             # In 1D we can use the primal basis as the expansion set,
             # avoiding any round-off coming from a basis transformation
             points = []

--- a/FIAT/nodal_enriched.py
+++ b/FIAT/nodal_enriched.py
@@ -35,16 +35,19 @@ class NodalEnrichedElement(CiarletElement):
                              "of NodalEnrichedElement are nodal")
 
         # Extract common data
-        ref_el = elements[0].get_reference_element()
-        expansion_set = elements[0].get_nodal_basis().get_expansion_set()
         degree = min(e.get_nodal_basis().get_degree() for e in elements)
         embedded_degree = max(e.get_nodal_basis().get_embedded_degree()
                               for e in elements)
         order = max(e.get_order() for e in elements)
-        mapping = elements[0].mapping()[0]
         formdegree = None if any(e.get_formdegree() is None for e in elements) \
             else max(e.get_formdegree() for e in elements)
-        value_shape = elements[0].value_shape()
+        # LagrangeExpansionSet set has fixed degree, ensure we grab the embedding one
+        elem = next(e for e in elements
+                    if e.get_nodal_basis().get_embedded_degree() == embedded_degree)
+        ref_el = elem.get_reference_element()
+        expansion_set = elem.get_nodal_basis().get_expansion_set()
+        mapping = elem.mapping()[0]
+        value_shape = elem.value_shape()
 
         # Sanity check
         assert all(e.get_nodal_basis().get_reference_element() ==

--- a/FIAT/polynomial_set.py
+++ b/FIAT/polynomial_set.py
@@ -132,13 +132,12 @@ class ONPolynomialSet(PolynomialSet):
         embedded_degree = degree
         expansion_set = expansions.ExpansionSet(ref_el)
 
+        # set up coefficients
         if shape == tuple():
             coeffs = numpy.eye(num_members)
         else:
-            # set up coefficients
             coeffs_shape = (num_members, *shape, num_exp_functions)
             coeffs = numpy.zeros(coeffs_shape, "d")
-
             # use functional's index_iterator function
             cur_bf = 0
             for idx in index_iterator(shape):
@@ -148,8 +147,8 @@ class ONPolynomialSet(PolynomialSet):
                     coeffs[cur_idx] = 1.0
                     cur_bf += 1
 
-        PolynomialSet.__init__(self, ref_el, degree, embedded_degree,
-                               expansion_set, coeffs)
+        super(ONPolynomialSet, self).__init__(ref_el, degree, embedded_degree,
+                                              expansion_set, coeffs)
 
 
 def project(f, U, Q):
@@ -240,5 +239,5 @@ class ONSymTensorPolynomialSet(PolynomialSet):
                     coeffs[cur_bf, j, i, exp_bf] = 1.0
                     cur_bf += 1
 
-        PolynomialSet.__init__(self, ref_el, degree, embedded_degree,
-                               expansion_set, coeffs)
+        super(ONSymTensorPolynomialSet, self).__init__(ref_el, degree, embedded_degree,
+                                                       expansion_set, coeffs)

--- a/FIAT/polynomial_set.py
+++ b/FIAT/polynomial_set.py
@@ -95,7 +95,7 @@ class PolynomialSet(object):
 
     def get_dmats(self):
         if len(self.dmats) == 0:
-            self.dmats = self.expansion_set.get_dmats(self.degree)
+            self.dmats = self.expansion_set.get_dmats(self.embedded_degree)
         return self.dmats
 
     def get_reference_element(self):

--- a/test/unit/test_fiat.py
+++ b/test/unit/test_fiat.py
@@ -379,17 +379,21 @@ def test_empty_bubble():
         Bubble(S, 3)
 
 
-def test_nodal_enriched_implementation():
+@pytest.mark.parametrize('elements', [
+    (Lagrange(I, 2), Lagrange(I, 1), Bubble(I, 2)),
+    (GaussLobattoLegendre(I, 3), Lagrange(I, 1),
+     RestrictedElement(GaussLobattoLegendre(I, 3), restriction_domain="interior")),
+    (RaviartThomas(T, 2),
+     RestrictedElement(RaviartThomas(T, 2), restriction_domain='facet'),
+     RestrictedElement(RaviartThomas(T, 2), restriction_domain='interior')),
+])
+def test_nodal_enriched_implementation(elements):
     """Following element pair should be the same.
     This might be fragile to dof reordering but works now.
     """
 
-    e0 = RaviartThomas(T, 2)
-
-    e1 = NodalEnrichedElement(
-        RestrictedElement(RaviartThomas(T, 2), restriction_domain='facet'),
-        RestrictedElement(RaviartThomas(T, 2), restriction_domain='interior')
-    )
+    e0 = elements[0]
+    e1 = NodalEnrichedElement(*elements[1:])
 
     for attr in ["degree",
                  "get_reference_element",


### PR DESCRIPTION
`NodalEnrichedElements` of mixed degree would break with elements using `LagrangeExpansionSets` if the first element is not the embedding one, e.g `Lagrange(interval, 1) + Bubble(interval, 2)`. LagrangeExpansionSets can only tabulate a fixed number of polynomials. This was not an issue with the Dubiner `ExpansionSet`, as these `ExpansionSets` do not have a fixed degree. 

Here we fix this by ensuring the resulting `NodalEnrichedElement` uses the `ExpansionSet` of the element that dictates the embedding degree.