### PR TITLE
Implement C0/C1 macroelements

### DIFF
--- a/FIAT/P0.py
+++ b/FIAT/P0.py
@@ -30,12 +30,12 @@ class P0Dual(dual_set.DualSet):
             entity_ids[dim] = {}
             entity_permutations[dim] = {}
             sym_size = ref_el.symmetry_group_size(dim)
-            perm = [0] if dim == sd else []
+            num_points = 1 if dim == sd else 0
             if isinstance(dim, tuple):
                 assert isinstance(sym_size, tuple)
-                perms = {o: perm for o in numpy.ndindex(sym_size)}
+                perms = {o: list(range(num_points)) for o in numpy.ndindex(sym_size)}
             else:
-                perms = {o: perm for o in range(sym_size)}
+                perms = {o: list(range(num_points)) for o in range(sym_size)}
             for entity in sorted(top[dim]):
                 entity_ids[dim][entity] = [entity] if dim == sd else []
                 entity_permutations[dim][entity] = perms

--- a/FIAT/P0.py
+++ b/FIAT/P0.py
@@ -17,34 +17,28 @@ import numpy
 class P0Dual(dual_set.DualSet):
     def __init__(self, ref_el):
         entity_ids = {}
-        nodes = []
         entity_permutations = {}
-        vs = numpy.array(ref_el.get_vertices())
-        if ref_el.get_dimension() == 0:
-            bary = ()
-        else:
-            bary = tuple(numpy.average(vs, 0))
-
-        nodes = [functional.PointEvaluation(ref_el, bary)]
-        entity_ids = {}
+        sd = ref_el.get_spatial_dimension()
         top = ref_el.get_topology()
+        if sd == 0:
+            pts = [tuple() for entity in sorted(top[sd])]
+        else:
+            pts = [tuple(numpy.average(ref_el.get_vertices_of_subcomplex(top[sd][entity]), 0))
+                   for entity in sorted(top[sd])]
+        nodes = [functional.PointEvaluation(ref_el, pt) for pt in pts]
         for dim in sorted(top):
             entity_ids[dim] = {}
             entity_permutations[dim] = {}
             sym_size = ref_el.symmetry_group_size(dim)
+            perm = [0] if dim == sd else []
             if isinstance(dim, tuple):
                 assert isinstance(sym_size, tuple)
-                perms = {o: [] for o in numpy.ndindex(sym_size)}
+                perms = {o: perm for o in numpy.ndindex(sym_size)}
             else:
-                perms = {o: [] for o in range(sym_size)}
+                perms = {o: perm for o in range(sym_size)}
             for entity in sorted(top[dim]):
-                entity_ids[dim][entity] = []
+                entity_ids[dim][entity] = [entity] if dim == sd else []
                 entity_permutations[dim][entity] = perms
-        entity_ids[dim] = {0: [0]}
-        if isinstance(dim, tuple):
-            entity_permutations[dim][0] = {o: [0] for o in numpy.ndindex(sym_size)}
-        else:
-            entity_permutations[dim][0] = {o: [0] for o in range(sym_size)}
 
         super(P0Dual, self).__init__(nodes, ref_el, entity_ids, entity_permutations)
 

--- a/FIAT/P0.py
+++ b/FIAT/P0.py
@@ -18,7 +18,7 @@ class P0Dual(dual_set.DualSet):
     def __init__(self, ref_el):
         entity_ids = {}
         entity_permutations = {}
-        sd = ref_el.get_spatial_dimension()
+        sd = ref_el.get_dimension()
         top = ref_el.get_topology()
         if sd == 0:
             pts = [tuple() for entity in sorted(top[sd])]

--- a/FIAT/__init__.py
+++ b/FIAT/__init__.py
@@ -7,6 +7,7 @@ import pkg_resources
 # Import finite element classes
 from FIAT.finite_element import FiniteElement, CiarletElement  # noqa: F401
 from FIAT.argyris import Argyris
+from FIAT.hct import HsiehCloughTocher
 from FIAT.bernstein import Bernstein
 from FIAT.bell import Bell
 from FIAT.argyris import QuinticArgyris
@@ -61,6 +62,7 @@ __version__ = pkg_resources.get_distribution("fenics-fiat").version
 
 # List of supported elements and mapping to element classes
 supported_elements = {"Argyris": Argyris,
+                      "HsiehCloughTocher": HsiehCloughTocher,
                       "Bell": Bell,
                       "Bernstein": Bernstein,
                       "Brezzi-Douglas-Marini": BrezziDouglasMarini,

--- a/FIAT/__init__.py
+++ b/FIAT/__init__.py
@@ -30,6 +30,7 @@ from FIAT.gauss_radau import GaussRadau
 from FIAT.morley import Morley
 from FIAT.nedelec import Nedelec
 from FIAT.nedelec_second_kind import NedelecSecondKind
+from FIAT.hierarchical import Legendre, IntegratedLegendre
 from FIAT.P0 import P0
 from FIAT.raviart_thomas import RaviartThomas
 from FIAT.crouzeix_raviart import CrouzeixRaviart
@@ -48,7 +49,6 @@ from FIAT.mixed import MixedElement                       # noqa: F401
 from FIAT.restricted import RestrictedElement             # noqa: F401
 from FIAT.quadrature_element import QuadratureElement     # noqa: F401
 from FIAT.kong_mulder_veldhuizen import KongMulderVeldhuizen  # noqa: F401
-from FIAT.hierarchical import Legendre, IntegratedLegendre  # noqa: F401
 from FIAT.fdm_element import FDMLagrange, FDMDiscontinuousLagrange, FDMQuadrature, FDMBrokenH1, FDMBrokenL2, FDMHermite  # noqa: F401
 
 # Important functionality
@@ -81,6 +81,8 @@ supported_elements = {"Argyris": Argyris,
                       "Gauss-Lobatto-Legendre": GaussLobattoLegendre,
                       "Gauss-Legendre": GaussLegendre,
                       "Gauss-Radau": GaussRadau,
+                      "Legendre": Legendre,
+                      "Integrated Legendre": IntegratedLegendre,
                       "Morley": Morley,
                       "Nedelec 1st kind H(curl)": Nedelec,
                       "Nedelec 2nd kind H(curl)": NedelecSecondKind,

--- a/FIAT/barycentric_interpolation.py
+++ b/FIAT/barycentric_interpolation.py
@@ -62,6 +62,7 @@ class LagrangeLineExpansionSet(expansions.LineExpansionSet):
             self.weights.append(wts)
 
         self.degree = max(len(wts) for wts in self.weights)-1
+        self.recurrence_order = self.degree + 1
         super(LagrangeLineExpansionSet, self).__init__(ref_el)
 
     def get_num_members(self, n):

--- a/FIAT/barycentric_interpolation.py
+++ b/FIAT/barycentric_interpolation.py
@@ -74,8 +74,8 @@ class LagrangeLineExpansionSet(expansions.LineExpansionSet):
     def get_points(self):
         return self.points
 
-    def get_dmats(self, degree):
-        return [dmat.T for dmat in self.dmats]
+    def get_dmats(self, degree, cell=0):
+        return self.dmats[cell].T
 
     def _tabulate(self, n, pts, order=0):
         num_members = self.get_num_members(n)
@@ -93,12 +93,8 @@ class LagrangeLineExpansionSet(expansions.LineExpansionSet):
                 indices = numpy.ix_(ibfs, ipts)
                 for result, val in zip(results, vals):
                     result[indices] = val
-
-        for r in range(order+1):
-            shape = results[r].shape
-            shape = shape[:1] + (1,)*r + shape[1:]
-            results[r] = numpy.reshape(results[r], shape)
-        return tuple(results)
+        tabulations = {(r,): results[r] for r in range(order+1)}
+        return tabulations
 
 
 class LagrangePolynomialSet(polynomial_set.PolynomialSet):

--- a/FIAT/barycentric_interpolation.py
+++ b/FIAT/barycentric_interpolation.py
@@ -53,7 +53,7 @@ class LagrangeLineExpansionSet(expansions.LineExpansionSet):
     def __init__(self, ref_el, pts):
         self.points = pts
         self.x = numpy.array(pts).flatten()
-        self.cell_node_map = expansions.compute_cell_point_map(ref_el, numpy.transpose(pts), unique=False)
+        self.cell_node_map = expansions.compute_cell_point_map(ref_el, pts, unique=False)
         self.dmats = []
         self.weights = []
         for ibfs in self.cell_node_map:

--- a/FIAT/barycentric_interpolation.py
+++ b/FIAT/barycentric_interpolation.py
@@ -75,7 +75,7 @@ class LagrangeLineExpansionSet(expansions.LineExpansionSet):
         return self.points
 
     def get_dmats(self, degree, cell=0):
-        return self.dmats[cell].T
+        return [self.dmats[cell].T]
 
     def _tabulate(self, n, pts, order=0):
         num_members = self.get_num_members(n)

--- a/FIAT/barycentric_interpolation.py
+++ b/FIAT/barycentric_interpolation.py
@@ -11,6 +11,15 @@ from FIAT import reference_element, expansions, polynomial_set
 from FIAT.functional import index_iterator
 
 
+def get_lagrange_points(nodes):
+    """Extract singleton point for each node."""
+    points = []
+    for node in nodes:
+        pt, = node.get_point_dict()
+        points.append(pt)
+    return points
+
+
 def barycentric_interpolation(nodes, wts, dmat, pts, order=0):
     """Evaluates a Lagrange basis on a line reference element
     via the second barycentric interpolation formula. See Berrut and Trefethen (2004)

--- a/FIAT/barycentric_interpolation.py
+++ b/FIAT/barycentric_interpolation.py
@@ -53,7 +53,7 @@ class LagrangeLineExpansionSet(expansions.LineExpansionSet):
     def __init__(self, ref_el, pts):
         self.points = pts
         self.x = numpy.array(pts).flatten()
-        self.cell_node_map = expansions.compute_cell_point_map(ref_el, numpy.transpose(pts))
+        self.cell_node_map = expansions.compute_cell_point_map(ref_el, numpy.transpose(pts), unique=False)
         self.dmats = []
         self.weights = []
         for ibfs in self.cell_node_map:

--- a/FIAT/check_format_variant.py
+++ b/FIAT/check_format_variant.py
@@ -38,20 +38,23 @@ def check_format_variant(variant, degree):
     return variant, interpolant_degree
 
 
-def parse_lagrange_variant(variant, discontinuous=False):
+def parse_lagrange_variant(variant, discontinuous=False, integral=False):
     if variant is None:
-        variant = "equispaced"
+        variant = "integral" if integral else "equispaced"
     options = variant.replace(" ", "").split(",")
     assert len(options) <= 2
 
-    if discontinuous:
+    default = "integral" if integral else "spectral"
+    if integral:
+        supported_point_variants = {"integral": None}
+    elif discontinuous:
         supported_point_variants = supported_dg_variants
     else:
         supported_point_variants = supported_cg_variants
 
     # defaults
     splitting = None
-    point_variant = supported_point_variants["spectral"]
+    point_variant = supported_point_variants[default]
 
     for pre_opt in options:
         opt = pre_opt.lower()

--- a/FIAT/check_format_variant.py
+++ b/FIAT/check_format_variant.py
@@ -1,4 +1,5 @@
 import re
+
 from FIAT.macro import AlfeldSplit, IsoSplit
 
 # dicts mapping Lagrange variant names to recursivenodes family names
@@ -39,6 +40,12 @@ def check_format_variant(variant, degree):
 
 
 def parse_lagrange_variant(variant, discontinuous=False, integral=False):
+    """Parses variant options for Lagrange elements.
+
+    variant may be a single option or comma-separated pair
+    indicating the dof type (integral, equispaced, spectral, etc)
+    and the type of splitting to give a macro-element (Alfeld, iso)
+    """
     if variant is None:
         variant = "integral" if integral else "equispaced"
     options = variant.replace(" ", "").split(",")

--- a/FIAT/check_format_variant.py
+++ b/FIAT/check_format_variant.py
@@ -54,6 +54,7 @@ def parse_lagrange_variant(variant, discontinuous=False, integral=False):
 
     # defaults
     splitting = None
+    splitting_args = tuple()
     point_variant = supported_point_variants[default]
 
     for pre_opt in options:
@@ -65,7 +66,8 @@ def parse_lagrange_variant(variant, discontinuous=False, integral=False):
         elif opt.startswith("iso"):
             match = re.match(r"^iso(?:\((\d+)\))?$", opt)
             k, = match.groups()
-            splitting = lambda T: IsoSplit(T, int(k))
+            call_split = IsoSplit
+            splitting_args = (int(k),)
         elif opt in supported_point_variants:
             point_variant = supported_point_variants[opt]
         else:
@@ -73,4 +75,6 @@ def parse_lagrange_variant(variant, discontinuous=False, integral=False):
 
     if discontinuous and splitting is not None and point_variant in supported_cg_variants.values():
         raise ValueError("Illegal variant. DG macroelements with DOFs on subcell boundaries are not unisolvent.")
+    if len(splitting_args) > 0:
+        splitting = lambda T: call_split(T, *splitting_args, point_variant or "gll")
     return splitting, point_variant

--- a/FIAT/check_format_variant.py
+++ b/FIAT/check_format_variant.py
@@ -23,13 +23,17 @@ def check_format_variant(variant, degree):
     return variant, interpolant_degree
 
 
-def parse_lagrange_variant(variant):
+def parse_lagrange_variant(variant, discontinuous=False):
     options = variant.replace(" ", "").split(",")
     assert len(options) <= 2
+    spectral = "gl" if discontinuous else "gll"
     supported_point_variants = {"equispaced": "equispaced",
                                 "gll": "gll",
-                                "spectral": "gll"}
-    point_variant = "gll"
+                                "spectral": spectral}
+    if discontinuous:
+        supported_point_variants["gl"] = "gl"
+
+    point_variant = spectral
 
     splitting = None
 

--- a/FIAT/discontinuous_lagrange.py
+++ b/FIAT/discontinuous_lagrange.py
@@ -178,7 +178,7 @@ class DiscontinuousLagrangeDualSet(dual_set.DualSet):
         nodes = []
         entity_ids = {}
         entity_permutations = {}
-        sd = ref_el.get_spatial_dimension()
+        sd = ref_el.get_dimension()
         top = ref_el.get_topology()
         for dim in sorted(top):
             entity_ids[dim] = {}

--- a/FIAT/discontinuous_lagrange.py
+++ b/FIAT/discontinuous_lagrange.py
@@ -10,7 +10,7 @@ import numpy as np
 from FIAT import finite_element, polynomial_set, dual_set, functional, P0
 from FIAT.reference_element import LINE, make_lattice
 from FIAT.orientation_utils import make_entity_permutations_simplex
-from FIAT.barycentric_interpolation import LagrangePolynomialSet
+from FIAT.barycentric_interpolation import LagrangePolynomialSet, get_lagrange_points
 from FIAT.polynomial_set import mis
 from FIAT.check_format_variant import parse_lagrange_variant
 
@@ -232,11 +232,7 @@ class DiscontinuousLagrange(finite_element.CiarletElement):
         if ref_el.shape == LINE:
             # In 1D we can use the primal basis as the expansion set,
             # avoiding any round-off coming from a basis transformation
-            points = []
-            for node in dual.nodes:
-                # Assert singleton point for each node.
-                pt, = node.get_point_dict().keys()
-                points.append(pt)
+            points = get_lagrange_points(dual)
             poly_set = LagrangePolynomialSet(ref_el, points)
         else:
             poly_set = polynomial_set.ONPolynomialSet(ref_el, degree)

--- a/FIAT/discontinuous_lagrange.py
+++ b/FIAT/discontinuous_lagrange.py
@@ -8,6 +8,9 @@
 import itertools
 import numpy as np
 from FIAT import finite_element, polynomial_set, dual_set, functional, P0
+from FIAT.reference_element import LINE, make_lattice
+from FIAT.orientation_utils import make_entity_permutations_simplex
+from FIAT.barycentric_interpolation import LagrangePolynomialSet
 from FIAT.polynomial_set import mis
 from FIAT.check_format_variant import parse_lagrange_variant
 
@@ -140,10 +143,10 @@ def make_entity_permutations(dim, npoints):
     return perms
 
 
-class DiscontinuousLagrangeDualSet(dual_set.DualSet):
+class BrokenLagrangeDualSet(dual_set.DualSet):
     """The dual basis for Lagrange elements.  This class works for
     simplices of any dimension.  Nodes are point evaluation at
-    equispaced points.  This is the discontinuous version where
+    equispaced points.  This is the broken version where
     all nodes are topologically associated with the cell itself"""
 
     def __init__(self, ref_el, degree, point_variant="equispaced"):
@@ -171,24 +174,61 @@ class DiscontinuousLagrangeDualSet(dual_set.DualSet):
                 entity_permutations[dim][entity] = perms
         entity_ids[dim][0] = list(range(len(nodes)))
 
+        super(BrokenLagrangeDualSet, self).__init__(nodes, ref_el, entity_ids, entity_permutations)
+
+
+class DiscontinuousLagrangeDualSet(dual_set.DualSet):
+    """The dual basis for discontinuous elements with nodes at recursively-defined points."""
+
+    def __init__(self, ref_el, degree, point_variant="equispaced"):
+        nodes = []
+        entity_ids = {}
+        entity_permutations = {}
+        sd = ref_el.get_spatial_dimension()
+        top = ref_el.get_topology()
+        for dim in sorted(top):
+            entity_ids[dim] = {}
+            entity_permutations[dim] = {}
+            perms = make_entity_permutations_simplex(dim, degree + 1 if dim == sd else -1)
+            for entity in sorted(top[dim]):
+                entity_ids[dim][entity] = []
+                entity_permutations[dim][entity] = perms
+
+        # make nodes by getting points
+        for entity in top[sd]:
+            cur = len(nodes)
+            pts = make_lattice(ref_el.get_vertices_of_subcomplex(top[sd][entity]),
+                               degree, variant=point_variant)
+            nodes.extend(functional.PointEvaluation(ref_el, x) for x in pts)
+            entity_ids[dim][entity] = list(range(cur, len(nodes)))
         super(DiscontinuousLagrangeDualSet, self).__init__(nodes, ref_el, entity_ids, entity_permutations)
 
 
-class HigherOrderDiscontinuousLagrange(finite_element.CiarletElement):
-    """The discontinuous Lagrange finite element."""
+class DiscontinuousLagrange(finite_element.CiarletElement):
+    """Simplicial discontinuous element with nodes at the (recursive) Gauss-Legendre points."""
+    def __new__(cls, ref_el, degree, variant="equsipaced"):
+        if degree == 0:
+            return P0.P0(ref_el)
+        return super(DiscontinuousLagrange, cls).__new__(cls)
 
     def __init__(self, ref_el, degree, variant="equispaced"):
-        splitting, point_variant = parse_lagrange_variant(variant)
+        splitting, point_variant = parse_lagrange_variant(variant, discontinuous=True)
         if splitting is not None:
             ref_el = splitting(ref_el)
-        dual = DiscontinuousLagrangeDualSet(ref_el, degree, point_variant=point_variant)
-        poly_set = polynomial_set.ONPolynomialSet(ref_el, degree)
+        if point_variant in ["equispaced", "gll"]:
+            dual = BrokenLagrangeDualSet(ref_el, degree, point_variant)
+        else:
+            dual = DiscontinuousLagrangeDualSet(ref_el, degree, point_variant)
+        if ref_el.shape == LINE:
+            # In 1D we can use the primal basis as the expansion set,
+            # avoiding any round-off coming from a basis transformation
+            points = []
+            for node in dual.nodes:
+                # Assert singleton point for each node.
+                pt, = node.get_point_dict().keys()
+                points.append(pt)
+            poly_set = LagrangePolynomialSet(ref_el, points)
+        else:
+            poly_set = polynomial_set.ONPolynomialSet(ref_el, degree)
         formdegree = ref_el.get_spatial_dimension()  # n-form
-        super(HigherOrderDiscontinuousLagrange, self).__init__(poly_set, dual, degree, formdegree)
-
-
-def DiscontinuousLagrange(ref_el, degree, variant="equispaced"):
-    if degree == 0:
-        return P0.P0(ref_el)
-    else:
-        return HigherOrderDiscontinuousLagrange(ref_el, degree, variant)
+        super(DiscontinuousLagrange, self).__init__(poly_set, dual, degree, formdegree)

--- a/FIAT/discontinuous_pc.py
+++ b/FIAT/discontinuous_pc.py
@@ -42,7 +42,7 @@ class DPC0(finite_element.CiarletElement):
         super(DPC0, self).__init__(poly_set=poly_set,
                                    dual=dual,
                                    order=degree,
-                                   ref_el=ref_el,
+                                   ref_complex=ref_el,
                                    formdegree=formdegree)
 
 
@@ -108,7 +108,7 @@ class HigherOrderDPC(finite_element.CiarletElement):
         super(HigherOrderDPC, self).__init__(poly_set=poly_set,
                                              dual=dual,
                                              order=degree,
-                                             ref_el=ref_el,
+                                             ref_complex=ref_el,
                                              formdegree=formdegree)
 
 

--- a/FIAT/dual_set.py
+++ b/FIAT/dual_set.py
@@ -198,7 +198,7 @@ def make_entity_closure_ids(ref_el, entity_ids):
 
 def merge_entity_ids(ref_el, entity_ids):
     """Collect DOFs from simplicial complex onto facets of parent cell"""
-    parent_cell = ref_el.parent
+    parent_cell = ref_el.get_parent()
     if parent_cell is None:
         return ref_el, entity_ids
 

--- a/FIAT/dual_set.py
+++ b/FIAT/dual_set.py
@@ -198,7 +198,6 @@ def make_entity_closure_ids(ref_el, entity_ids):
 
 def merge_entities(ref_el, entity_ids, entity_permutations):
     """Collect DOFs from simplicial complex onto facets of parent cell"""
-    from FIAT.orientation_utils import make_entity_permutations_simplex
     parent_cell = ref_el.get_parent()
     if parent_cell is None:
         return ref_el, entity_ids, entity_permutations
@@ -212,16 +211,5 @@ def merge_entities(ref_el, entity_ids, entity_permutations):
             dofs_cur = entity_ids[dim][entity]
             parent_ids[parent_dim][parent_id].extend(dofs_cur)
 
-    if entity_permutations is None:
-        parent_permutations = None
-    else:
-        parent_permutations = {}
-        npoints = 0
-        for dim in sorted(parent_top):
-            if dim <= 1:
-                npoints = len(parent_ids[dim][0])
-            perms = make_entity_permutations_simplex(dim, npoints)
-            parent_permutations[dim] = {entity: perms for entity in parent_top[dim]}
-            npoints -= 1
-
+    parent_permutations = None
     return parent_cell, parent_ids, parent_permutations

--- a/FIAT/dual_set.py
+++ b/FIAT/dual_set.py
@@ -32,6 +32,9 @@ class DualSet(object):
                 ids.sort()
                 self.entity_closure_ids[d][e] = ids
 
+    def __iter__(self):
+        return iter(self.nodes)
+
     def get_nodes(self):
         return self.nodes
 

--- a/FIAT/dual_set.py
+++ b/FIAT/dual_set.py
@@ -205,8 +205,8 @@ def merge_entities(ref_el, entity_ids, entity_permutations):
     parent_top = parent_cell.get_topology()
     parent_ids = {dim: {entity: [] for entity in parent_top[dim]} for dim in parent_top}
     child_to_parent = ref_el.get_child_to_parent()
-    for dim in child_to_parent:
-        for entity in child_to_parent[dim]:
+    for dim in sorted(child_to_parent):
+        for entity in sorted(child_to_parent[dim]):
             parent_dim, parent_id = child_to_parent[dim][entity]
             dofs_cur = entity_ids[dim][entity]
             parent_ids[parent_dim][parent_id].extend(dofs_cur)

--- a/FIAT/expansions.py
+++ b/FIAT/expansions.py
@@ -430,21 +430,23 @@ class ExpansionSet(object):
     def tabulate(self, n, pts):
         if len(pts) == 0:
             return numpy.array([])
-        sd = self.ref_el.get_spatial_dimension()
-        return self._tabulate(n, numpy.transpose(pts))[(0,)*sd]
+        D = self.ref_el.get_spatial_dimension()
+        return self._tabulate(n, numpy.transpose(pts))[(0,) * D]
 
     def tabulate_derivatives(self, n, pts):
         from FIAT.polynomial_set import mis
         vals = self._tabulate(n, numpy.transpose(pts), order=1)
         # Create the ordinary data structure.
         D = self.ref_el.get_spatial_dimension()
-        data = [[(vals[(0,) * D][i, j], [vals[alpha][i, j] for alpha in mis(D, 1)])
-                 for j in range(len(vals[0]))]
-                for i in range(len(vals))]
+        v = vals[(0,) * D]
+        dv = [vals[alpha] for alpha in mis(D, 1)]
+        data = [[(v[i, j], [vi[i, j] for vi in dv])
+                 for j in range(v.shape[1])]
+                for i in range(v.shape[0])]
         return data
 
     def tabulate_jet(self, n, pts, order=1):
-        vals = self._tabulate(n, pts, order=order)
+        vals = self._tabulate(n, numpy.transpose(pts), order=order)
         # Create the ordinary data structure.
         D = self.ref_el.get_spatial_dimension()
         v0 = vals[(0,)*D]

--- a/FIAT/expansions.py
+++ b/FIAT/expansions.py
@@ -519,7 +519,7 @@ class TetrahedronExpansionSet(ExpansionSet):
 
 def polynomial_dimension(ref_el, n, continuity=None):
     """Returns the dimension of the space of polynomials of degree no
-    greater than n on the reference element."""
+    greater than n on the reference complex."""
     if ref_el.get_shape() == reference_element.POINT:
         if n > 0:
             raise ValueError("Only degree zero polynomials supported on point elements.")
@@ -534,7 +534,7 @@ def polynomial_dimension(ref_el, n, continuity=None):
 
 
 def polynomial_entity_ids(ref_el, n, continuity=None):
-    """Maps facets to members of a polynomial basis.
+    """Maps entites of a cell complex to members of a polynomial basis.
 
     :arg ref_el: a SimplicialComplex.
     :arg n: the polynomial degree of the expansion set.

--- a/FIAT/expansions.py
+++ b/FIAT/expansions.py
@@ -162,10 +162,9 @@ def dubiner_recurrence(dim, n, order, ref_pts, Jinv, scale, variant=None):
             if variant is not None:
                 p = index[-1] + shift
                 alpha = 2 * (sum(index[:-1]) + d * shift) - 1
-                norm2 = 1.0
+                norm2 = (2*d+1) / (2*d)
                 if p > 0 and p + alpha > 0:
-                    norm2 = (p + alpha) * (2*p + alpha) / p
-                    norm2 *= (2*d+1) / (2*d)
+                    norm2 *= (p + alpha) * (2*p + alpha) / p
             else:
                 norm2 = (2*sum(index) + d) / d
             scale = math.sqrt(norm2)

--- a/FIAT/expansions.py
+++ b/FIAT/expansions.py
@@ -358,7 +358,7 @@ class ExpansionSet(object):
         cell_node_map = self.get_cell_node_map(n)
         result = {}
         for alpha in phis[0]:
-            result[alpha] = numpy.zeros((num_phis, len(pts)))
+            result[alpha] = numpy.zeros((num_phis,) + pts.shape[:-1])
             for ibfs, ipts, phi in zip(cell_node_map, cell_point_map, phis):
                 result[alpha][numpy.ix_(ibfs, ipts)] = phi[alpha]
         return result
@@ -380,7 +380,7 @@ class ExpansionSet(object):
         cell_node_map = self.get_cell_node_map(n)
 
         num_phis = self.get_num_members(n)
-        results = [numpy.zeros((num_phis,) + (sd,) * (r-1) + (len(pts),))
+        results = [numpy.zeros((num_phis,) + (sd,) * (r-1) + pts.shape[:-1])
                    for r in range(order+1)]
 
         for k, (ibfs, ipts) in enumerate(zip(cell_node_map, cell_point_map)):
@@ -395,6 +395,7 @@ class ExpansionSet(object):
                         vr[index] = phi[tuple(map(index.count, range(sd)))]
                     if r > 0:
                         vr = numpy.tensordot(normal, vr, axes=(0, 0))
+                    vr = vr.transpose((-2, *tuple(range(r-1)), -1))
 
                     shape_indices = tuple(range(sd) for _ in range(r-1))
                     indices = numpy.ix_(ibfs, *shape_indices, ipts)

--- a/FIAT/expansions.py
+++ b/FIAT/expansions.py
@@ -420,28 +420,28 @@ class ExpansionSet(object):
         if degree == 0:
             return cache.setdefault(key, numpy.zeros((self.ref_el.get_spatial_dimension(), 1, 1), "d"))
 
-        sd = self.ref_el.get_spatial_dimension()
+        D = self.ref_el.get_dimension()
         top = self.ref_el.get_topology()
-        verts = self.ref_el.get_vertices_of_subcomplex(top[sd][cell])
+        verts = self.ref_el.get_vertices_of_subcomplex(top[D][cell])
         pts = reference_element.make_lattice(verts, degree, variant="gl")
         v = self._tabulate_on_cell(degree, pts, order=1, cell=cell)
-        dv = [numpy.transpose(v[alpha]) for alpha in mis(sd, 1)]
-        dmats = numpy.linalg.solve(numpy.transpose(v[(0,)*sd]), dv)
+        dv = [numpy.transpose(v[alpha]) for alpha in mis(D, 1)]
+        dmats = numpy.linalg.solve(numpy.transpose(v[(0,) * D]), dv)
         return cache.setdefault(key, dmats)
 
     def tabulate(self, n, pts):
         if len(pts) == 0:
             return numpy.array([])
-        D = self.ref_el.get_spatial_dimension()
-        return self._tabulate(n, pts)[(0,) * D]
+        sd = self.ref_el.get_spatial_dimension()
+        return self._tabulate(n, pts)[(0,) * sd]
 
     def tabulate_derivatives(self, n, pts):
         from FIAT.polynomial_set import mis
         vals = self._tabulate(n, pts, order=1)
         # Create the ordinary data structure.
-        D = self.ref_el.get_spatial_dimension()
-        v = vals[(0,) * D]
-        dv = [vals[alpha] for alpha in mis(D, 1)]
+        sd = self.ref_el.get_spatial_dimension()
+        v = vals[(0,) * sd]
+        dv = [vals[alpha] for alpha in mis(sd, 1)]
         data = [[(v[i, j], [vi[i, j] for vi in dv])
                  for j in range(v.shape[1])]
                 for i in range(v.shape[0])]
@@ -450,13 +450,13 @@ class ExpansionSet(object):
     def tabulate_jet(self, n, pts, order=1):
         vals = self._tabulate(n, pts, order=order)
         # Create the ordinary data structure.
-        D = self.ref_el.get_spatial_dimension()
-        v0 = vals[(0,)*D]
+        sd = self.ref_el.get_spatial_dimension()
+        v0 = vals[(0,) * sd]
         data = [v0]
         for r in range(1, order+1):
-            vr = numpy.zeros((D,)*r + v0.shape, dtype=v0.dtype)
+            vr = numpy.zeros((sd,) * r + v0.shape, dtype=v0.dtype)
             for index in numpy.ndindex(vr.shape[:r]):
-                vr[index] = vals[tuple(map(index.count, range(D)))]
+                vr[index] = vals[tuple(map(index.count, range(sd)))]
             data.append(vr.transpose((r, r+1) + tuple(range(r))))
         return data
 

--- a/FIAT/expansions.py
+++ b/FIAT/expansions.py
@@ -332,8 +332,7 @@ class ExpansionSet(object):
             result = numpy.zeros((num_phis,) + (sd,)*r + pts.shape[1:])
             for ibfs, ipts, phi in zip(cell_node_map, cell_point_map, phis):
                 shape_indices = tuple(range(sd) for _ in range(r))
-                indices = (ibfs,) + shape_indices + (ipts,)
-                result[numpy.ix_(*indices)] = phi[r]
+                result[numpy.ix_(ibfs, *shape_indices, ipts)] = phi[r]
             results.append(result)
         return tuple(results)
 

--- a/FIAT/expansions.py
+++ b/FIAT/expansions.py
@@ -67,7 +67,7 @@ def dubiner_recurrence(dim, n, order, ref_pts, Jinv, scale, variant=None):
 
     :arg dim: The spatial dimension of the simplex.
     :arg n: The polynomial degree.
-    :arg order: The maximum order of differenation.
+    :arg order: The maximum order of differentiation.
     :arg ref_pts: An ``ndarray`` with the coordinates on the default (-1, 1)^d simplex.
     :arg Jinv: The inverse of the Jacobian of the coordinate mapping from the default simplex.
     :arg scale: A scale factor that sets the first member of expansion set.
@@ -247,7 +247,7 @@ def xi_tetrahedron(eta):
 
 
 def apply_mapping(A, b, pts):
-    """Apply an affine mapping to an d-by-npts array of points."""
+    """Apply an affine mapping to an column-stacked array of points."""
     if isinstance(pts, numpy.ndarray) and len(pts.shape) == 2:
         return numpy.dot(A, pts) + b[:, None]
     else:
@@ -545,7 +545,7 @@ def compute_cell_point_map(ref_el, pts, tol=1E-12):
     """Maps cells on a simplicial complex to points.
 
     :arg ref_el: a SimplicialComplex.
-    :arg pts: a d-by-npts array of physical coordinates.
+    :arg pts: a column-stacked array of physical coordinates.
     :kwarg tol: the absolute tolerance.
     :returns: a numpy array mapping cell id to points located on that cell.
     """

--- a/FIAT/finite_element.py
+++ b/FIAT/finite_element.py
@@ -129,9 +129,9 @@ class CiarletElement(FiniteElement):
     basis generated from polynomials encoded in a `PolynomialSet`.
     """
 
-    def __init__(self, poly_set, dual, order, formdegree=None, mapping="affine", ref_el=None):
-        ref_el = ref_el or dual.get_reference_element()
-        ref_complex = poly_set.get_reference_element()
+    def __init__(self, poly_set, dual, order, formdegree=None, mapping="affine", ref_complex=None):
+        ref_el = dual.get_reference_element()
+        ref_complex = ref_complex or poly_set.get_reference_element()
         super(CiarletElement, self).__init__(ref_el, dual, order, formdegree, mapping, ref_complex)
 
         # build generalized Vandermonde matrix

--- a/FIAT/finite_element.py
+++ b/FIAT/finite_element.py
@@ -129,9 +129,9 @@ class CiarletElement(FiniteElement):
     basis generated from polynomials encoded in a `PolynomialSet`.
     """
 
-    def __init__(self, poly_set, dual, order, formdegree=None, mapping="affine", ref_el=None, ref_complex=None):
+    def __init__(self, poly_set, dual, order, formdegree=None, mapping="affine", ref_el=None):
         ref_el = ref_el or dual.get_reference_element()
-        ref_complex = ref_complex or ref_el
+        ref_complex = poly_set.get_reference_element()
         super(CiarletElement, self).__init__(ref_el, dual, order, formdegree, mapping, ref_complex)
 
         # build generalized Vandermonde matrix
@@ -156,7 +156,6 @@ class CiarletElement(FiniteElement):
         new_shp = new_coeffs_flat.shape[:1] + shp[1:]
         new_coeffs = new_coeffs_flat.reshape(new_shp)
 
-        # dual might advertise the parent cell but poly_set might be on a simplicial complex
         self.poly_set = PolynomialSet(poly_set.get_reference_element(),
                                       poly_set.get_degree(),
                                       poly_set.get_embedded_degree(),

--- a/FIAT/gauss_legendre.py
+++ b/FIAT/gauss_legendre.py
@@ -8,53 +8,10 @@
 #
 # Modified by Pablo D. Brubeck (brubeck@protonmail.com), 2021
 
-from FIAT import finite_element, polynomial_set, dual_set, functional
-from FIAT.reference_element import POINT, LINE, TRIANGLE, TETRAHEDRON
-from FIAT.orientation_utils import make_entity_permutations_simplex
-from FIAT.barycentric_interpolation import LagrangePolynomialSet
-from FIAT.reference_element import make_lattice
+from FIAT import discontinuous_lagrange
 
 
-class GaussLegendreDualSet(dual_set.DualSet):
-    """The dual basis for discontinuous elements with nodes at the
-    (recursive) Gauss-Legendre points."""
-
-    def __init__(self, ref_el, degree):
-        entity_ids = {}
-        entity_permutations = {}
-        top = ref_el.get_topology()
-        for dim in sorted(top):
-            entity_ids[dim] = {}
-            entity_permutations[dim] = {}
-            perms = make_entity_permutations_simplex(dim, degree + 1 if dim == len(top)-1 else -1)
-            for entity in sorted(top[dim]):
-                entity_ids[dim][entity] = []
-                entity_permutations[dim][entity] = perms
-
-        # make nodes by getting points
-        dim = ref_el.get_spatial_dimension()
-        pts = make_lattice(ref_el.get_vertices(), degree, variant="gl")
-        nodes = [functional.PointEvaluation(ref_el, x) for x in pts]
-        entity_ids[dim][0] = list(range(len(nodes)))
-        super(GaussLegendreDualSet, self).__init__(nodes, ref_el, entity_ids, entity_permutations)
-
-
-class GaussLegendre(finite_element.CiarletElement):
+class GaussLegendre(discontinuous_lagrange.DiscontinuousLagrange):
     """Simplicial discontinuous element with nodes at the (recursive) Gauss-Legendre points."""
     def __init__(self, ref_el, degree):
-        if ref_el.shape not in {POINT, LINE, TRIANGLE, TETRAHEDRON}:
-            raise ValueError("Gauss-Legendre elements are only defined on simplices.")
-        dual = GaussLegendreDualSet(ref_el, degree)
-        if ref_el.shape == LINE:
-            # In 1D we can use the primal basis as the expansion set,
-            # avoiding any round-off coming from a basis transformation
-            points = []
-            for node in dual.nodes:
-                # Assert singleton point for each node.
-                pt, = node.get_point_dict().keys()
-                points.append(pt)
-            poly_set = LagrangePolynomialSet(ref_el, points)
-        else:
-            poly_set = polynomial_set.ONPolynomialSet(ref_el, degree)
-        formdegree = ref_el.get_spatial_dimension()  # n-form
-        super(GaussLegendre, self).__init__(poly_set, dual, degree, formdegree)
+        super(GaussLegendre, self).__init__(ref_el, degree, variant="gl")

--- a/FIAT/gauss_lobatto_legendre.py
+++ b/FIAT/gauss_lobatto_legendre.py
@@ -12,6 +12,6 @@ from FIAT import lagrange
 
 
 class GaussLobattoLegendre(lagrange.Lagrange):
-    """Simplicial continuous element with nodes at the (recursive) Gauss-Lobatto points."""
+    """Simplicial continuous element with nodes at the (recursive) Gauss-Lobatto-Legendre points."""
     def __init__(self, ref_el, degree):
         super(GaussLobattoLegendre, self).__init__(ref_el, degree, variant="gll")

--- a/FIAT/hct.py
+++ b/FIAT/hct.py
@@ -28,9 +28,9 @@ class HCTDualSet(dual_set.DualSet):
             entity_ids[0][v].extend(range(cur, len(nodes)))
 
         rline = ufc_simplex(1)
-        Q = create_quadrature(rline, degree-1)
-        qpts = Q.get_points()
         k = 2 if reduced else 0
+        Q = create_quadrature(rline, degree-1+k)
+        qpts = Q.get_points()
         f_at_qpts = eval_jacobi(0, 0, k, 2.0*qpts - 1)
         for e in sorted(top[1]):
             cur = len(nodes)

--- a/FIAT/hct.py
+++ b/FIAT/hct.py
@@ -25,7 +25,7 @@ class HCTDualSet(dual_set.DualSet):
             entity_ids[0][v].extend(range(cur, len(nodes)))
 
         rline = ufc_simplex(1)
-        Q = create_quadrature(rline, 2*(degree-1))
+        Q = create_quadrature(rline, degree-1)
         qpts = Q.get_points()
         scale = numpy.ones(qpts.shape)
         for e in sorted(top[1]):

--- a/FIAT/hct.py
+++ b/FIAT/hct.py
@@ -3,6 +3,7 @@ from FIAT import finite_element, dual_set, macro, polynomial_set
 from FIAT.reference_element import ufc_simplex
 from FIAT.jacobi import eval_jacobi
 from FIAT.quadrature_schemes import create_quadrature
+import numpy
 
 
 class HCTDualSet(dual_set.DualSet):
@@ -27,10 +28,10 @@ class HCTDualSet(dual_set.DualSet):
         rline = ufc_simplex(1)
         Q = create_quadrature(rline, 2*(degree-1))
         qpts = Q.get_points()
-        leg2_at_qpts = eval_jacobi(0, 0, degree-1, 2.0*qpts - 1)
+        scale = numpy.ones(qpts.shape)
         for e in sorted(top[1]):
             cur = len(nodes)
-            nodes.append(IntegralMomentOfNormalDerivative(ref_el, e, Q, leg2_at_qpts))
+            nodes.append(IntegralMomentOfNormalDerivative(ref_el, e, Q, scale))
             entity_ids[1][e].extend(range(cur, len(nodes)))
 
         return super(HCTDualSet, self).__init__(nodes, ref_el, entity_ids)

--- a/FIAT/hct.py
+++ b/FIAT/hct.py
@@ -42,5 +42,5 @@ class HsiehCloughTocher(finite_element.CiarletElement):
 
     def __init__(self, ref_el, degree=3):
         dual = HCTDualSet(ref_el, degree)
-        poly_set = macro.C1PolynomialSet(macro.AlfeldSplit(ref_el), degree)
+        poly_set = macro.C1PolynomialSet(macro.AlfeldSplit(ref_el), degree, variant="bubble")
         super(HsiehCloughTocher, self).__init__(poly_set, dual, degree)

--- a/FIAT/hct.py
+++ b/FIAT/hct.py
@@ -37,7 +37,7 @@ class HCTDualSet(dual_set.DualSet):
             nodes.append(IntegralMomentOfNormalDerivative(ref_el, e, Q, f_at_qpts))
             entity_ids[1][e].extend(range(cur, len(nodes)))
 
-        return super(HCTDualSet, self).__init__(nodes, ref_el, entity_ids)
+        super(HCTDualSet, self).__init__(nodes, ref_el, entity_ids)
 
 
 class HsiehCloughTocher(finite_element.CiarletElement):

--- a/FIAT/hct.py
+++ b/FIAT/hct.py
@@ -1,5 +1,6 @@
 from FIAT.functional import PointEvaluation, PointDerivative, IntegralMomentOfNormalDerivative
 from FIAT import finite_element, dual_set, macro, polynomial_set
+from FIAT.reference_element import ufc_simplex
 from FIAT.jacobi import eval_jacobi
 from FIAT.quadrature_schemes import create_quadrature
 
@@ -23,13 +24,10 @@ class HCTDualSet(dual_set.DualSet):
             nodes.extend(PointDerivative(ref_el, pt, alpha) for alpha in alphas)
             entity_ids[0][v].extend(range(cur, len(nodes)))
 
-        rline = ref_el.construct_subelement(1)
-        rline_verts = rline.get_vertices()
-        x0, = rline_verts[0]
-        x1, = rline_verts[1]
+        rline = ufc_simplex(1)
         Q = create_quadrature(rline, 2*(degree-1))
         qpts = Q.get_points()
-        leg2_at_qpts = eval_jacobi(0, 0, degree-1, 2.0*(qpts-x0)/(x1-x0) - 1)
+        leg2_at_qpts = eval_jacobi(0, 0, degree-1, 2.0*qpts - 1)
         for e in sorted(top[1]):
             cur = len(nodes)
             nodes.append(IntegralMomentOfNormalDerivative(ref_el, e, Q, leg2_at_qpts))

--- a/FIAT/hct.py
+++ b/FIAT/hct.py
@@ -1,7 +1,6 @@
 from FIAT.functional import PointEvaluation, PointDerivative, IntegralMomentOfNormalDerivative
 from FIAT import finite_element, dual_set, macro, polynomial_set
 from FIAT.reference_element import ufc_simplex
-from FIAT.jacobi import eval_jacobi
 from FIAT.quadrature_schemes import create_quadrature
 import numpy
 

--- a/FIAT/hct.py
+++ b/FIAT/hct.py
@@ -1,4 +1,5 @@
-from FIAT.functional import PointEvaluation, PointDerivative, IntegralMomentOfNormalDerivative
+from FIAT.functional import (PointEvaluation, PointDerivative,
+                             IntegralMomentOfNormalDerivative)
 from FIAT import finite_element, dual_set, macro, polynomial_set
 from FIAT.reference_element import ufc_simplex
 from FIAT.quadrature_schemes import create_quadrature

--- a/FIAT/hct.py
+++ b/FIAT/hct.py
@@ -42,5 +42,5 @@ class HsiehCloughTocher(finite_element.CiarletElement):
 
     def __init__(self, ref_el, degree=3):
         dual = HCTDualSet(ref_el, degree)
-        poly_set = macro.C1PolynomialSet(macro.AlfeldSplit(ref_el), degree, variant="bubble")
+        poly_set = macro.CkPolynomialSet(macro.AlfeldSplit(ref_el), degree, variant=None)
         super(HsiehCloughTocher, self).__init__(poly_set, dual, degree)

--- a/FIAT/hierarchical.py
+++ b/FIAT/hierarchical.py
@@ -20,23 +20,34 @@ from FIAT.polynomial_set import ONPolynomialSet, make_bubbles
 
 class LegendreDual(dual_set.DualSet):
     """The dual basis for Legendre elements."""
-    def __init__(self, ref_el, degree, poly_set):
+    def __init__(self, ref_el, degree, codim=0):
+        nodes = []
         entity_ids = {}
         entity_permutations = {}
+
+        sd = ref_el.get_spatial_dimension()
         top = ref_el.get_topology()
         for dim in sorted(top):
-            entity_ids[dim] = {}
+            npoints = degree + 1 if dim == sd - codim else 0
+            perms = make_entity_permutations_simplex(dim, npoints)
             entity_permutations[dim] = {}
-            perms = make_entity_permutations_simplex(dim, degree + 1 if dim == len(top)-1 else -1)
-            for entity in sorted(top[dim]):
-                entity_ids[dim][entity] = []
-                entity_permutations[dim][entity] = perms
+            entity_ids[dim] = {}
+            if npoints == 0:
+                for entity in sorted(top[dim]):
+                    entity_ids[dim][entity] = []
+                    entity_permutations[dim][entity] = perms
+                continue
 
-        dim = ref_el.get_spatial_dimension()
-        Q = create_quadrature(ref_el, 2 * degree)
-        phis = poly_set.tabulate(Q.get_points())[(0,) * dim]
-        nodes = [functional.IntegralMoment(ref_el, Q, phi) for phi in phis]
-        entity_ids[dim][0] = list(range(len(nodes)))
+            ref_facet = ref_el.construct_subelement(dim)
+            poly_set = ONPolynomialSet(ref_facet, degree)
+            Q_ref = create_quadrature(ref_facet, 2 * degree)
+            phis = poly_set.tabulate(Q_ref.get_points())[(0,) * dim]
+            for entity in sorted(top[dim]):
+                cur = len(nodes)
+                Q_facet = FacetQuadratureRule(ref_el, dim, entity, Q_ref)
+                nodes.extend(functional.IntegralMoment(ref_el, Q_facet, phi) for phi in phis)
+                entity_ids[dim][entity] = list(range(cur, len(nodes)))
+                entity_permutations[dim][entity] = perms
 
         super(LegendreDual, self).__init__(nodes, ref_el, entity_ids, entity_permutations)
 
@@ -48,7 +59,7 @@ class Legendre(finite_element.CiarletElement):
         if ref_el.shape not in {POINT, LINE, TRIANGLE, TETRAHEDRON}:
             raise ValueError("%s is only defined on simplices." % type(self))
         poly_set = ONPolynomialSet(ref_el, degree)
-        dual = LegendreDual(ref_el, degree, poly_set)
+        dual = LegendreDual(ref_el, degree)
         formdegree = ref_el.get_spatial_dimension()  # n-form
         super(Legendre, self).__init__(poly_set, dual, degree, formdegree)
 
@@ -56,8 +67,6 @@ class Legendre(finite_element.CiarletElement):
 class IntegratedLegendreDual(dual_set.DualSet):
     """The dual basis for integrated Legendre elements."""
     def __init__(self, ref_el, degree):
-        duals = self._beuchler_integral_duals
-
         nodes = []
         entity_ids = {}
         entity_permutations = {}
@@ -77,7 +86,7 @@ class IntegratedLegendreDual(dual_set.DualSet):
                 continue
 
             ref_facet = symmetric_simplex(dim)
-            Q_ref, phis = duals(ref_facet, degree)
+            Q_ref, phis = self.make_reference_duals(ref_facet, degree)
             for entity in sorted(top[dim]):
                 cur = len(nodes)
                 Q_facet = FacetQuadratureRule(ref_el, dim, entity, Q_ref)
@@ -92,7 +101,7 @@ class IntegratedLegendreDual(dual_set.DualSet):
 
         super(IntegratedLegendreDual, self).__init__(nodes, ref_el, entity_ids, entity_permutations)
 
-    def _beuchler_integral_duals(self, ref_el, degree):
+    def make_reference_duals(self, ref_el, degree):
         Q = create_quadrature(ref_el, 2 * degree)
         qpts, qwts = Q.get_points(), Q.get_weights()
         inner = lambda v, u: numpy.dot(numpy.multiply(v, qwts), u.T)

--- a/FIAT/hierarchical.py
+++ b/FIAT/hierarchical.py
@@ -63,7 +63,7 @@ class Legendre(finite_element.CiarletElement):
         return super(Legendre, cls).__new__(cls)
 
     def __init__(self, ref_el, degree, variant=None):
-        splitting, _ = parse_lagrange_variant(variant, discontinuous=True)
+        splitting, _ = parse_lagrange_variant(variant, integral=True)
         if splitting is not None:
             ref_el = splitting(ref_el)
         poly_set = ONPolynomialSet(ref_el, degree)
@@ -132,7 +132,7 @@ class IntegratedLegendreDual(dual_set.DualSet):
 class IntegratedLegendre(finite_element.CiarletElement):
     """Simplicial continuous element with integrated Legendre polynomials."""
     def __init__(self, ref_el, degree, variant=None):
-        splitting, _ = parse_lagrange_variant(variant)
+        splitting, _ = parse_lagrange_variant(variant, integral=True)
         if splitting is not None:
             ref_el = splitting(ref_el)
         if degree < 1:

--- a/FIAT/hierarchical.py
+++ b/FIAT/hierarchical.py
@@ -56,7 +56,7 @@ class Legendre(finite_element.CiarletElement):
     """Simplicial discontinuous element with Legendre polynomials."""
     def __new__(cls, ref_el, degree, variant=None):
         if degree == 0:
-            splitting, _ = parse_lagrange_variant(variant, discontinuous=True)
+            splitting, _ = parse_lagrange_variant(variant, integral=True)
             if splitting is None:
                 # FIXME P0 on the split requires implementing SplitSimplicialComplex.symmetry_group_size()
                 return P0.P0(ref_el)

--- a/FIAT/hsieh_clough_tocher.py
+++ b/FIAT/hsieh_clough_tocher.py
@@ -1,0 +1,47 @@
+from FIAT.functional import PointEvaluation, PointDerivative, IntegralMomentOfNormalDerivative
+from FIAT import finite_element, dual_set, macro, polynomial_set
+from FIAT.jacobi import eval_jacobi
+from FIAT.quadrature_schemes import create_quadrature
+
+
+class HCTDualSet(dual_set.DualSet):
+    def __init__(self, ref_el, degree):
+        if degree != 3:
+            raise ValueError("HCT elements only defined for degree=3")
+        top = ref_el.get_topology()
+        verts = ref_el.get_vertices()
+        sd = ref_el.get_spatial_dimension()
+        entity_ids = {dim: {entity: [] for entity in sorted(top[dim])} for dim in sorted(top)}
+
+        # get first order jet at each vertex
+        alphas = polynomial_set.mis(sd, 1)
+        nodes = []
+        for v in sorted(top[0]):
+            pt = verts[v]
+            cur = len(nodes)
+            nodes.append(PointEvaluation(ref_el, pt))
+            nodes.extend(PointDerivative(ref_el, pt, alpha) for alpha in alphas)
+            entity_ids[0][v].extend(range(cur, len(nodes)))
+
+        rline = ref_el.construct_subelement(1)
+        rline_verts = rline.get_vertices()
+        x0, = rline_verts[0]
+        x1, = rline_verts[1]
+        Q = create_quadrature(rline, 2*(degree-1))
+        qpts = Q.get_points()
+        leg2_at_qpts = eval_jacobi(0, 0, degree-1, 2.0*(qpts-x0)/(x1-x0) - 1)
+        for e in sorted(top[1]):
+            cur = len(nodes)
+            nodes.append(IntegralMomentOfNormalDerivative(ref_el, e, Q, leg2_at_qpts))
+            entity_ids[1][e].extend(range(cur, len(nodes)))
+
+        return super(HCTDualSet, self).__init__(nodes, ref_el, entity_ids)
+
+
+class HsiehCloughTocher(finite_element.CiarletElement):
+    """The HCT finite element."""
+
+    def __init__(self, ref_el, degree=3):
+        dual = HCTDualSet(ref_el, degree)
+        poly_set = macro.C1PolynomialSet(macro.AlfeldSplit(ref_el), degree)
+        super(HsiehCloughTocher, self).__init__(poly_set, dual, degree)

--- a/FIAT/jacobi.py
+++ b/FIAT/jacobi.py
@@ -18,7 +18,8 @@ def eval_jacobi(a, b, n, x):
     given in Karniadakis and Sherwin, Appendix B"""
 
     if 0 == n:
-        return 1.0
+        # Get zeros of the right shape
+        return 0.0 * x + 1.0
     elif 1 == n:
         return 0.5 * (a - b + (a + b + 2.0) * x)
     else:  # 2 <= n

--- a/FIAT/lagrange.py
+++ b/FIAT/lagrange.py
@@ -7,7 +7,7 @@
 
 from FIAT import finite_element, polynomial_set, dual_set, functional
 from FIAT.orientation_utils import make_entity_permutations_simplex
-from FIAT.barycentric_interpolation import LagrangePolynomialSet
+from FIAT.barycentric_interpolation import LagrangePolynomialSet, get_lagrange_points
 from FIAT.reference_element import LINE
 from FIAT.check_format_variant import parse_lagrange_variant
 
@@ -67,11 +67,7 @@ class Lagrange(finite_element.CiarletElement):
         if ref_el.shape == LINE:
             # In 1D we can use the primal basis as the expansion set,
             # avoiding any round-off coming from a basis transformation
-            points = []
-            for node in dual.nodes:
-                # Assert singleton point for each node.
-                pt, = node.get_point_dict().keys()
-                points.append(pt)
+            points = get_lagrange_points(dual)
             poly_set = LagrangePolynomialSet(ref_el, points)
         else:
             poly_variant = "bubble" if ref_el.is_macrocell() else None

--- a/FIAT/lagrange.py
+++ b/FIAT/lagrange.py
@@ -40,7 +40,6 @@ class LagrangeDualSet(dual_set.DualSet):
                 entity_ids[dim][entity] = list(range(cur, cur + nnodes_cur))
                 cur += nnodes_cur
                 entity_permutations[dim][entity] = perms
-
         super(LagrangeDualSet, self).__init__(nodes, ref_el, entity_ids, entity_permutations)
 
 

--- a/FIAT/lagrange.py
+++ b/FIAT/lagrange.py
@@ -79,4 +79,4 @@ class Lagrange(finite_element.CiarletElement):
             poly_variant = "bubble" if num_cells > 1 else None
             poly_set = polynomial_set.ONPolynomialSet(ref_el, degree, variant=poly_variant)
         formdegree = 0  # 0-form
-        super(Lagrange, self).__init__(poly_set, dual, degree, formdegree, ref_complex=ref_el)
+        super(Lagrange, self).__init__(poly_set, dual, degree, formdegree)

--- a/FIAT/lagrange.py
+++ b/FIAT/lagrange.py
@@ -40,6 +40,7 @@ class LagrangeDualSet(dual_set.DualSet):
                 entity_ids[dim][entity] = list(range(cur, cur + nnodes_cur))
                 cur += nnodes_cur
                 entity_permutations[dim][entity] = perms
+
         super(LagrangeDualSet, self).__init__(nodes, ref_el, entity_ids, entity_permutations)
 
 

--- a/FIAT/lagrange.py
+++ b/FIAT/lagrange.py
@@ -15,8 +15,8 @@ from FIAT.check_format_variant import parse_lagrange_variant
 class LagrangeDualSet(dual_set.DualSet):
     """The dual basis for Lagrange elements.  This class works for
     simplices of any dimension.  Nodes are point evaluation at
-    equispaced points."""
-
+    recursively-defined points.
+    """
     def __init__(self, ref_el, degree, point_variant="equispaced"):
         entity_ids = {}
         nodes = []
@@ -58,7 +58,6 @@ class Lagrange(finite_element.CiarletElement):
                            variant='Alfeld' can be used to obtain a barycentrically refined
                               macroelement for Scott-Vogelius.
     """
-
     def __init__(self, ref_el, degree, variant="equispaced"):
         splitting, point_variant = parse_lagrange_variant(variant)
         if splitting is not None:

--- a/FIAT/macro.py
+++ b/FIAT/macro.py
@@ -121,6 +121,12 @@ class SplitSimplicialComplex(SimplicialComplex):
                     connectivity[cell][dim].append(inv_top[dim][global_verts])
         self._cell_connectivity = connectivity
 
+        # dict mapping subentity dimension to interior facets
+        interior_facets = {dim: [entity for entity in child_to_parent[dim]
+                                 if child_to_parent[dim][entity][0] == sd]
+                           for dim in sorted(child_to_parent)}
+        self._interior_facets = interior_facets
+
         super(SplitSimplicialComplex, self).__init__(parent.shape, vertices, topology)
 
     def get_child_to_parent(self):
@@ -140,14 +146,13 @@ class SplitSimplicialComplex(SimplicialComplex):
         """
         return self._cell_connectivity
 
-    def get_interior_facets(self, dim):
-        """Returns the dim-dimensional facets supported on the parent's interior.
+    def get_interior_facets(self, dimension):
+        """Returns the list of entities of the given dimension that are
+        supported on the parent's interior.
+
+        :arg dimension: subentity dimension (integer)
         """
-        sd = self.get_spatial_dimension()
-        child_to_parent = self.get_child_to_parent()
-        interior_facets = [facet for facet in child_to_parent[dim]
-                           if child_to_parent[dim][facet][0] == sd]
-        return interior_facets
+        return self._interior_facets[dimension]
 
     def construct_subelement(self, dimension):
         """Constructs the reference element of a cell subentity

--- a/FIAT/macro.py
+++ b/FIAT/macro.py
@@ -1,8 +1,11 @@
 import copy
-import numpy
 from itertools import chain
-from FIAT.reference_element import make_lattice, lattice_iter, SimplicialComplex
-from FIAT.quadrature import QuadratureRule, FacetQuadratureRule
+
+import numpy
+
+from FIAT.quadrature import FacetQuadratureRule, QuadratureRule
+from FIAT.reference_element import (SimplicialComplex, lattice_iter,
+                                    make_lattice)
 
 
 def bary_to_xy(verts, bary, result=None):

--- a/FIAT/macro.py
+++ b/FIAT/macro.py
@@ -335,10 +335,13 @@ class CkPolynomialSet(polynomial_set.PolynomialSet):
                 dimPk = 1 if sd == 1 else expansions.polynomial_dimension(facet_el, degree - r)
                 rows.append(numpy.dot(weights[:dimPk], jumps[r].T))
 
-        dual_mat = numpy.row_stack(rows)
-        _, sig, vt = numpy.linalg.svd(dual_mat, full_matrices=True)
-        num_sv = len([s for s in sig if abs(s) > 1.e-10])
-        coeffs = vt[num_sv:]
+        if len(rows) == 0:
+            coeffs = numpy.eye(expansion_set.get_num_members(degree))
+        else:
+            dual_mat = numpy.row_stack(rows)
+            _, sig, vt = numpy.linalg.svd(dual_mat, full_matrices=True)
+            num_sv = len([s for s in sig if abs(s) > 1.e-10])
+            coeffs = vt[num_sv:]
 
         if shape != tuple():
             m, n = coeffs.shape

--- a/FIAT/macro.py
+++ b/FIAT/macro.py
@@ -320,7 +320,7 @@ class CkPolynomialSet(polynomial_set.PolynomialSet):
 
     :arg ref_el: The simplicial complex.
     :arg degree: The polynomial degree.
-    :kwarg order: The differentiation order of continuity across subcells.
+    :kwarg order: The order of continuity across subcells.
     :kwarg shape: The value shape.
     :kwarg variant: The variant for the underlying ExpansionSet.
     :kwarg scale: The scale for the underlying ExpansionSet.
@@ -328,7 +328,6 @@ class CkPolynomialSet(polynomial_set.PolynomialSet):
     def __init__(self, ref_el, degree, order=1, shape=(), **kwargs):
         from FIAT.quadrature_schemes import create_quadrature
         expansion_set = expansions.ExpansionSet(ref_el, **kwargs)
-        num_members = expansion_set.get_num_members(degree)
         k = 1 if expansion_set.continuity == "C0" else 0
 
         sd = ref_el.get_spatial_dimension()
@@ -345,17 +344,16 @@ class CkPolynomialSet(polynomial_set.PolynomialSet):
         for facet in ref_el.get_interior_facets(sd-1):
             jumps = expansion_set.tabulate_normal_jumps(degree, qpts, facet, order=order)
             for r in range(k, order+1):
-                dimPk = 1 if sd == 1 else expansions.polynomial_dimension(facet_el, degree - r)
-                rows.append(numpy.tensordot(weights[:dimPk], jumps[r].T,
-                                            axes=(-1, 0)).reshape((-1, num_members)))
+                num_wt = 1 if sd == 1 else expansions.polynomial_dimension(facet_el, degree-r)
+                rows.append(numpy.tensordot(weights[:num_wt], jumps[r], axes=(-1, -1)).reshape(-1, jumps[r].shape[0]))
 
-        if len(rows) == 0:
-            coeffs = numpy.eye(num_members)
-        else:
+        if len(rows) > 0:
             dual_mat = numpy.row_stack(rows)
             _, sig, vt = numpy.linalg.svd(dual_mat, full_matrices=True)
             num_sv = len([s for s in sig if abs(s) > 1.e-10])
             coeffs = vt[num_sv:]
+        else:
+            coeffs = numpy.eye(expansion_set.get_num_members(degree))
 
         if shape != tuple():
             m, n = coeffs.shape
@@ -363,3 +361,50 @@ class CkPolynomialSet(polynomial_set.PolynomialSet):
             coeffs = numpy.tile(coeffs, (1,) + shape + (1,))
 
         super(CkPolynomialSet, self).__init__(ref_el, degree, degree, expansion_set, coeffs)
+
+
+class HDivSymPolynomialSet(polynomial_set.PolynomialSet):
+    """Constructs a symmetric tensor-valued PolynomialSet with continuous
+       normal components on a simplicial complex.
+
+    :arg ref_el: The simplicial complex.
+    :arg degree: The polynomial degree.
+    :kwarg order: The order of continuity across subcells.
+    :kwarg variant: The variant for the underlying ExpansionSet.
+    :kwarg scale: The scale for the underlying ExpansionSet.
+    """
+    def __init__(self, ref_el, degree, order=0, **kwargs):
+        from FIAT.quadrature_schemes import create_quadrature
+        U = polynomial_set.ONSymTensorPolynomialSet(ref_el, degree, **kwargs)
+        coeffs = U.get_coeffs()
+        expansion_set = U.get_expansion_set()
+        k = 1 if expansion_set.continuity == "C0" else 0
+
+        sd = ref_el.get_spatial_dimension()
+        facet_el = ref_el.construct_subelement(sd-1)
+
+        phi_deg = 0 if sd == 1 else degree - k
+        phi = polynomial_set.ONPolynomialSet(facet_el, phi_deg, shape=(sd,))
+        Q = create_quadrature(facet_el, 2 * phi_deg)
+        qpts, qwts = Q.get_points(), Q.get_weights()
+        phi_at_qpts = phi.tabulate(qpts)[(0,) * (sd-1)]
+        weights = numpy.multiply(phi_at_qpts, qwts)
+
+        rows = []
+        for facet in ref_el.get_interior_facets(sd-1):
+            normal = ref_el.compute_normal(facet)
+            jumps = expansion_set.tabulate_normal_jumps(degree, qpts, facet, order=order)
+            for r in range(k, order+1):
+                jump = numpy.dot(coeffs, jumps[r])
+                # num_wt = 1 if sd == 1 else expansions.polynomial_dimension(facet_el, degree-r)
+                wn = weights[:, :, None, :] * normal[None, None, :, None]
+                ax = tuple(range(1, len(wn.shape)))
+                rows.append(numpy.tensordot(wn, jump, axes=(ax, ax)))
+
+        if len(rows) > 0:
+            dual_mat = numpy.row_stack(rows)
+            _, sig, vt = numpy.linalg.svd(dual_mat, full_matrices=True)
+            num_sv = len([s for s in sig if abs(s) > 1.e-10])
+            coeffs = numpy.tensordot(vt[num_sv:], coeffs, axes=(1, 0))
+
+        super(HDivSymPolynomialSet, self).__init__(ref_el, degree, degree, expansion_set, coeffs)

--- a/FIAT/macro.py
+++ b/FIAT/macro.py
@@ -140,6 +140,15 @@ class SplitSimplicialComplex(SimplicialComplex):
         """
         return self._cell_connectivity
 
+    def get_interior_facets(self, dim):
+        """Returns the dim-dimensional facets supported on the parent's interior.
+        """
+        sd = self.get_spatial_dimension()
+        child_to_parent = self.get_child_to_parent()
+        interior_facets = [facet for facet in child_to_parent[dim]
+                           if child_to_parent[dim][facet][0] == sd]
+        return interior_facets
+
     def construct_subelement(self, dimension):
         """Constructs the reference element of a cell subentity
         specified by subelement dimension.
@@ -153,13 +162,6 @@ class SplitSimplicialComplex(SimplicialComplex):
 
     def get_parent(self):
         return self._parent
-
-    def get_interior_facets(self, dim):
-        sd = self.get_spatial_dimension()
-        child_to_parent = self.get_child_to_parent()
-        interior_facets = [facet for facet in child_to_parent[dim]
-                           if child_to_parent[dim][facet][0] == sd]
-        return interior_facets
 
 
 class AlfeldSplit(SplitSimplicialComplex):
@@ -189,6 +191,9 @@ class AlfeldSplit(SplitSimplicialComplex):
         super(AlfeldSplit, self).__init__(ref_el, new_verts, new_topology)
 
     def construct_subcomplex(self, dimension):
+        """Constructs the reference subcomplex of the parent cell subentity
+        specified by subcomplex dimension.
+        """
         if dimension == self.get_dimension():
             return self
         # Alfed on facets is just a simplex
@@ -251,6 +256,9 @@ class IsoSplit(SplitSimplicialComplex):
         super(IsoSplit, self).__init__(ref_el, new_verts, new_topology)
 
     def construct_subcomplex(self, dimension):
+        """Constructs the reference subcomplex of the parent cell subentity
+        specified by subcomplex dimension.
+        """
         if dimension == self.get_dimension():
             return self
         ref_el = self.construct_subelement(dimension)

--- a/FIAT/macro.py
+++ b/FIAT/macro.py
@@ -328,6 +328,7 @@ class CkPolynomialSet(polynomial_set.PolynomialSet):
     def __init__(self, ref_el, degree, order=1, shape=(), **kwargs):
         from FIAT.quadrature_schemes import create_quadrature
         expansion_set = expansions.ExpansionSet(ref_el, **kwargs)
+        num_members = expansion_set.get_num_members(degree)
         k = 1 if expansion_set.continuity == "C0" else 0
 
         sd = ref_el.get_spatial_dimension()
@@ -345,10 +346,11 @@ class CkPolynomialSet(polynomial_set.PolynomialSet):
             jumps = expansion_set.tabulate_normal_jumps(degree, qpts, facet, order=order)
             for r in range(k, order+1):
                 dimPk = 1 if sd == 1 else expansions.polynomial_dimension(facet_el, degree - r)
-                rows.append(numpy.dot(weights[:dimPk], jumps[r].T))
+                rows.append(numpy.tensordot(weights[:dimPk], jumps[r].T,
+                                            axes=(-1, 0)).reshape((-1, num_members)))
 
         if len(rows) == 0:
-            coeffs = numpy.eye(expansion_set.get_num_members(degree))
+            coeffs = numpy.eye(num_members)
         else:
             dual_mat = numpy.row_stack(rows)
             _, sig, vt = numpy.linalg.svd(dual_mat, full_matrices=True)

--- a/FIAT/macro.py
+++ b/FIAT/macro.py
@@ -162,6 +162,12 @@ class AlfeldSplit(SplitSimplicialComplex):
                 new_topology[dim][offset+entity] = ids + (new_vert_id,)
         super(AlfeldSplit, self).__init__(ref_el, new_verts, new_topology)
 
+    def construct_subcomplex(self, dimension):
+        if dimension == self.get_dimension():
+            return self
+        # Alfed on facets is just a simplex
+        return self.construct_subelement(dimension)
+
 
 class IsoSplit(SplitSimplicialComplex):
     """Splits simplex into the simplicial complex obtained by
@@ -172,6 +178,8 @@ class IsoSplit(SplitSimplicialComplex):
     :kwarg variant: The point distribution variant.
     """
     def __init__(self, ref_el, degree=2, variant=None):
+        self.degree = degree
+        self.variant = variant
         # Construct new vertices entity-by-entity
         sd = ref_el.get_spatial_dimension()
         top = ref_el.get_topology()
@@ -226,6 +234,16 @@ class IsoSplit(SplitSimplicialComplex):
                         entities.append((v,) + facet)
             new_topology[dim] = dict(enumerate(entities))
         super(IsoSplit, self).__init__(ref_el, new_verts, new_topology)
+
+    def construct_subcomplex(self, dimension):
+        if dimension == self.get_dimension():
+            return self
+        ref_el = self.construct_subelement(dimension)
+        if dimension == 0:
+            return ref_el
+        else:
+            # Iso on facets is Iso
+            return IsoSplit(ref_el, self.degree, self.variant)
 
 
 class MacroQuadratureRule(QuadratureRule):

--- a/FIAT/macro.py
+++ b/FIAT/macro.py
@@ -6,16 +6,24 @@ from FIAT.quadrature import QuadratureRule, FacetQuadratureRule
 
 
 def bary_to_xy(verts, bary, result=None):
-    # verts is (sdim + 1) x sdim so verts[i, :] is i:th vertex
-    # bary is [npts, sdim + 1]
-    # result is [npts, sdim]
+    """Maps barycentric coordinates to physical points.
+
+    :arg verts: A tuple of points.
+    :arg bary: A row-stacked numpy array of barycentric coordinates.
+    :arg result: A row-stacked numpy array of physical points.
+    :returns: result
+    """
     return numpy.dot(bary, verts, out=result)
 
 
 def xy_to_bary(verts, pts, result=None):
-    # verts is (sdim + 1) x sdim so verts[i, :] is i:th vertex
-    # result is [npts, sdim]
-    # bary is [npts, sdim + 1]
+    """Maps physical points to barycentric coordinates.
+
+    :arg verts: A tuple of points.
+    :arg ots: A row-stacked numpy array of physical points.
+    :arg result: A row-stacked numpy array of barycentric coordinates.
+    :returns: result
+    """
     verts = numpy.asarray(verts)
     npts = pts.shape[0]
     sdim = verts.shape[1]
@@ -31,60 +39,83 @@ def xy_to_bary(verts, pts, result=None):
 
 
 def facet_support(facet_coords, tol=1.e-12):
-    # facet_coords is an iterable of tuples (barycentric coordinates)
-    # return vertex ids where some x is nonzero
+    """Returns the support of a facet.
+
+    :arg facet_coords: An iterable of tuples (barycentric coordinates) describing the facet.
+    :returns: A tuple of vertex ids where some coordinate is nonzero.
+    """
     return tuple(sorted(set(i for x in facet_coords for (i, xi) in enumerate(x) if abs(xi) > tol)))
 
 
 def invert_cell_topology(T):
+    """Returns a dict of dicts mapping dimension x vertices to entity id."""
     return {dim: {T[dim][entity]: entity for entity in T[dim]} for dim in T}
 
 
 class SplitSimplicialComplex(SimplicialComplex):
     """Abstract class to implement a split on a Simplex
     """
-
     def __init__(self, ref_el, splits=1, variant=None):
         vertices, topology = self.split_topology(ref_el, splits=splits, variant=variant)
+
+        bary = xy_to_bary(numpy.asarray(ref_el.get_vertices()), numpy.asarray(vertices))
+        parent_top = ref_el.get_topology()
+        parent_inv_top = invert_cell_topology(parent_top)
+
+        # dict mapping child facets to their parent facet
+        child_to_parent = {}
+        # dict mapping parent facets to their children
+        parent_to_children = {dim: {entity: [] for entity in parent_top[dim]} for dim in parent_top}
+        for dim in topology:
+            child_to_parent[dim] = {}
+            for entity in topology[dim]:
+                facet_ids = topology[dim][entity]
+                facet_coords = bary[list(facet_ids), :]
+                parent_verts = facet_support(facet_coords)
+                parent_dim = len(parent_verts) - 1
+                parent_entity = parent_inv_top[parent_dim][parent_verts]
+                child_to_parent[dim][entity] = (parent_dim, parent_entity)
+                parent_to_children[parent_dim][parent_entity].append((dim, entity))
+
+        self._child_to_parent = child_to_parent
+        self._parent_to_children = parent_to_children
+
+        sd = ref_el.get_spatial_dimension()
+        inv_top = invert_cell_topology(topology)
+
+        # dict mapping cells to boundary facets for each dimension,
+        # while respecting the ordering on the parent simplex
+        connectivity = {cell: {dim: [] for dim in topology} for cell in topology[sd]}
+        for cell in topology[sd]:
+            cell_verts = topology[sd][cell]
+            for dim in top:
+                for entity in parent_top[dim]:
+                    ref_verts = parent_top[dim][entity]
+                    global_verts = tuple(cell_verts[v] for v in ref_verts)
+                    connectivity[cell][dim].append(inv_top[dim][global_verts])
+        self._cell_connectivity = connectivity
+
         super(SplitSimplicialComplex, self).__init__(ref_el.shape, vertices, topology, parent=ref_el)
 
     def split_topology(self, ref_el):
         raise NotImplementedError
 
     def get_child_to_parent(self):
-        bary = xy_to_bary(numpy.asarray(self.parent.get_vertices()),
-                          numpy.asarray(self.get_vertices()))
-        top = self.get_topology()
-        parent_inv_top = invert_cell_topology(self.parent.get_topology())
-        child_to_parent = {}
-        for dim in top:
-            child_to_parent[dim] = {}
-            for entity in top[dim]:
-                facet_ids = top[dim][entity]
-                facet_coords = bary[list(facet_ids), :]
-                parent_verts = facet_support(facet_coords)
-                parent_dim = len(parent_verts) - 1
-                parent_entity = parent_inv_top[parent_dim][parent_verts]
-                child_to_parent[dim][entity] = (parent_dim, parent_entity)
-        return child_to_parent
+        """Maps split complex facet tuple to its parent entity tuple."""
+        return self._child_to_parent
+
+    def get_parent_to_children(self):
+        """Maps parent facet tuple to a list of tuples of entites in the split complex."""
+        return self._parent_to_children
 
     def get_cell_connectivity(self):
-        """Connectitivity from cell in a complex to globally number and
+        """Connectitivity from cell in a complex to global facet ids and
         respects the entity numbering on the reference cell.
+
+        N.B. cell_connectivity[cell][dim] has the same contents as
+        self.connectivity[(sd, dim)][cell], except those are sorted.
         """
-        sd = self.get_spatial_dimension()
-        top = self.get_topology()
-        inv_top = invert_cell_topology(top)
-        parent_top = self.parent.get_topology()
-        connectivity = {cell: {dim: [] for dim in top} for cell in top[sd]}
-        for cell in top[sd]:
-            cell_verts = top[sd][cell]
-            for dim in top:
-                for entity in parent_top[dim]:
-                    ref_verts = parent_top[dim][entity]
-                    global_verts = tuple(cell_verts[v] for v in ref_verts)
-                    connectivity[cell][dim].append(inv_top[dim][global_verts])
-        return connectivity
+        return self._cell_connectivity
 
     def construct_subelement(self, dimension):
         """Constructs the reference element of a cell subentity
@@ -96,20 +127,25 @@ class SplitSimplicialComplex(SimplicialComplex):
 
 
 class AlfeldSplit(SplitSimplicialComplex):
-
+    """Alfeld splitting of a simplex.
+    """
     def split_topology(self, ref_el, splits=1, variant=None):
         assert splits == 1
         sd = ref_el.get_spatial_dimension()
         top = ref_el.get_topology()
+        # Keep old facets, respecting the old numbering
         new_topology = copy.deepcopy(top)
+        # Discard the cell interior
         new_topology[sd] = {}
 
+        # Append the barycenter as the new vertex
         barycenter = ref_el.make_points(sd, 0, sd+1)
         old_verts = ref_el.get_vertices()
         new_verts = old_verts + tuple(barycenter)
         new_vert_id = len(old_verts)
-
         new_topology[0][new_vert_id] = (new_vert_id,)
+
+        # Append new facets by adding the barycenter to old facets
         for dim in range(1, sd + 1):
             offset = len(new_topology[dim])
             for entity, ids in top[dim-1].items():
@@ -167,19 +203,34 @@ class IsoSplit(SplitSimplicialComplex):
 
 
 class MacroQuadratureRule(QuadratureRule):
+    """Composite quadrature rule on parent facets that respects the splitting.
 
-    def __init__(self, cell_complex, Q_ref):
+    :arg ref_el: A simplicial complex.
+    :arg Q_ref: A QuadratureRule on the reference simplex.
+    :args parent_facets: An iterable of facets of the same dimension as Q_ref,
+                         defaults to all facets.
+
+    :returns: A quadrature rule on the sub entities of the simplicial complex.
+    """
+    def __init__(self, ref_el, Q_ref, parent_facets=None):
+        parent_dim = Q_ref.ref_el.get_spatial_dimension()
+        if parent_facets is not None:
+            parent_cell = ref_el.parent
+            parent_to_children = parent_cell.get_parent_to_children()
+            facets = []
+            for parent_entity in parent_facets:
+                children = parent_to_children[parent_dim][parent_entity]
+                facets.extend(entity for dim, entity in children if dim == parent_dim)
+        else:
+            top = ref_el.get_topology()
+            facets = top[parent_dim]
+
         pts = []
         wts = []
-        sd = cell_complex.get_spatial_dimension()
-        ref_el = cell_complex.construct_subelement(sd)
-        t = cell_complex.get_topology()
-        dim = Q_ref.ref_el.get_spatial_dimension()
-        for entity in t[dim]:
-            Q_cur = FacetQuadratureRule(cell_complex, dim, entity, Q_ref)
+        for entity in facets:
+            Q_cur = FacetQuadratureRule(ref_el, parent_dim, entity, Q_ref)
             pts.extend(Q_cur.pts)
             wts.extend(Q_cur.wts)
-
         pts = tuple(pts)
         wts = tuple(wts)
         super(MacroQuadratureRule, self).__init__(ref_el, pts, wts)

--- a/FIAT/macro.py
+++ b/FIAT/macro.py
@@ -227,7 +227,6 @@ class IsoSplit(SplitSimplicialComplex):
         new_topology[1] = dict(enumerate(edges))
 
         # Get an adjacency list for each vertex
-        edges = new_topology[1].values()
         adjacency = {v: set(chain.from_iterable(verts for verts in edges if v in verts))
                      for v in new_topology[0]}
 

--- a/FIAT/macro.py
+++ b/FIAT/macro.py
@@ -56,6 +56,7 @@ class SplitSimplicialComplex(SimplicialComplex):
     """Abstract class to implement a split on a Simplex
     """
     def __init__(self, ref_el, splits=1, variant=None):
+        self._parent = ref_el
         vertices, topology = self.split_topology(ref_el, splits=splits, variant=variant)
 
         bary = xy_to_bary(numpy.asarray(ref_el.get_vertices()), numpy.asarray(vertices))
@@ -88,14 +89,14 @@ class SplitSimplicialComplex(SimplicialComplex):
         connectivity = {cell: {dim: [] for dim in topology} for cell in topology[sd]}
         for cell in topology[sd]:
             cell_verts = topology[sd][cell]
-            for dim in top:
+            for dim in parent_top:
                 for entity in parent_top[dim]:
                     ref_verts = parent_top[dim][entity]
                     global_verts = tuple(cell_verts[v] for v in ref_verts)
                     connectivity[cell][dim].append(inv_top[dim][global_verts])
         self._cell_connectivity = connectivity
 
-        super(SplitSimplicialComplex, self).__init__(ref_el.shape, vertices, topology, parent=ref_el)
+        super(SplitSimplicialComplex, self).__init__(ref_el.shape, vertices, topology)
 
     def split_topology(self, ref_el):
         raise NotImplementedError
@@ -123,10 +124,13 @@ class SplitSimplicialComplex(SimplicialComplex):
 
         :arg dimension: subentity dimension (integer)
         """
-        return self.parent.construct_subelement(dimension)
+        return self.get_parent().construct_subelement(dimension)
 
     def is_macrocell(self):
         return True
+
+    def get_parent(self):
+        return self._parent
 
 
 class AlfeldSplit(SplitSimplicialComplex):

--- a/FIAT/macro.py
+++ b/FIAT/macro.py
@@ -4,8 +4,7 @@ from itertools import chain
 import numpy
 
 from FIAT.quadrature import FacetQuadratureRule, QuadratureRule
-from FIAT.reference_element import (SimplicialComplex, lattice_iter,
-                                    make_lattice)
+from FIAT.reference_element import SimplicialComplex, lattice_iter
 
 
 def bary_to_xy(verts, bary, result=None):
@@ -23,11 +22,12 @@ def xy_to_bary(verts, pts, result=None):
     """Maps physical points to barycentric coordinates.
 
     :arg verts: A tuple of points.
-    :arg ots: A row-stacked numpy array of physical points.
+    :arg pts: A row-stacked numpy array of physical points.
     :arg result: A row-stacked numpy array of barycentric coordinates.
     :returns: result
     """
     verts = numpy.asarray(verts)
+    pts = numpy.asarray(pts)
     npts = pts.shape[0]
     sdim = verts.shape[1]
 
@@ -171,33 +171,44 @@ class IsoSplit(SplitSimplicialComplex):
     :kwarg depth: The number of subdivisions along each edge of the simplex.
     :kwarg variant: The point distribution variant.
     """
-    def __init__(self, ref_el, depth=2, variant=None):
+    def __init__(self, ref_el, degree=2, variant=None):
+        # Construct new vertices entity-by-entity
         sd = ref_el.get_spatial_dimension()
-        old_verts = ref_el.get_vertices()
-        new_verts = make_lattice(old_verts, depth, variant=variant)
+        top = ref_el.get_topology()
+        new_verts = []
+        ref_lattice = []
+        for dim in top:
+            for entity in top[dim]:
+                new_verts.extend(ref_el.make_points(dim, entity, degree, variant=variant))
+                ref_lattice.extend(ref_el.make_points(dim, entity, degree))
+
+        bary = xy_to_bary(ref_el.vertices, ref_lattice)
+        bary *= degree
+        alphas = numpy.rint(bary[:, :-1])
+        flat_index = {tuple(alpha): i for i, alpha in enumerate(alphas)}
 
         new_topology = {}
         new_topology[0] = {i: (i,) for i in range(len(new_verts))}
         new_topology[1] = {}
-
-        # Loop through vertex pairs
-        # Edges are oriented from low vertex id to high vertex id to avoid duplicates
-        # Place a new edge when the two lattice multiindices are at Manhattan distance < 3,
-        # this connects the midpoints of edges within a face
-        # Only include diagonal edges that are parallel to the simplex edges,
-        # we take the diagonal that goes through vertices at the same depth
+        # Loop through degree k-1 vertices
+        # Construct a P1 simplex by connecting edges between this vertex and each of its neighbors by shifing each coordinate up by 1,
+        # forming a P1 simplex
         cur = 0
-        distance = lambda x, y: sum(abs(b-a) for a, b in zip(x, y))
-        for j, v1 in enumerate(lattice_iter(0, depth+1, sd)):
-            for i, v0 in enumerate(lattice_iter(0, depth+1, sd)):
-                if i < j and distance(v0, v1) < 3 and sum(v1) - sum(v0) <= 1:
-                    new_topology[1][cur] = (i, j)
+        for alpha in lattice_iter(0, degree, sd):
+            simplex = []
+            for beta in lattice_iter(0, 2, sd):
+                v1 = flat_index[tuple(a+b for a, b in zip(alpha, beta))]
+                for v0 in simplex:
+                    new_topology[1][cur] = tuple(sorted((v0, v1)))
                     cur = cur + 1
+                simplex.append(v1)
+
         if sd == 3:
             # Cut the octahedron
             # FIXME do this more generically
-            assert depth == 2
-            new_topology[1][cur] = (1, 8)
+            assert degree == 2
+            v0, v1 = flat_index[(1, 0, 0)], flat_index[(0, 1, 1)]
+            new_topology[1][cur] = tuple(sorted((v0, v1)))
 
         # Get an adjacency list for each vertex
         edges = new_topology[1].values()

--- a/FIAT/polynomial_set.py
+++ b/FIAT/polynomial_set.py
@@ -68,7 +68,7 @@ class PolynomialSet(object):
 
     def tabulate(self, pts, jet_order=0):
         """Returns the values of the polynomial set."""
-        base_vals = self.expansion_set._tabulate(self.embedded_degree, numpy.transpose(pts), order=jet_order)
+        base_vals = self.expansion_set._tabulate(self.embedded_degree, pts, order=jet_order)
 
         result = {alpha: numpy.dot(self.coeffs, base_vals[alpha]) for alpha in base_vals}
         return result

--- a/FIAT/polynomial_set.py
+++ b/FIAT/polynomial_set.py
@@ -61,7 +61,6 @@ class PolynomialSet(object):
         self.embedded_degree = embedded_degree
         self.expansion_set = expansion_set
         self.coeffs = coeffs
-        self.dmats = []
 
     def tabulate_new(self, pts):
         return numpy.dot(self.coeffs,
@@ -69,12 +68,9 @@ class PolynomialSet(object):
 
     def tabulate(self, pts, jet_order=0):
         """Returns the values of the polynomial set."""
-        base_vals = self.expansion_set._tabulate_jet(self.embedded_degree, pts, order=jet_order)
-        D = self.ref_el.get_spatial_dimension()
-        result = {}
-        for i in range(jet_order + 1):
-            for alpha in mis(D, i):
-                result[alpha] = numpy.dot(self.coeffs, base_vals[alpha])
+        base_vals = self.expansion_set._tabulate(self.embedded_degree, numpy.transpose(pts), order=jet_order)
+
+        result = {alpha: numpy.dot(self.coeffs, base_vals[alpha]) for alpha in base_vals}
         return result
 
     def get_expansion_set(self):
@@ -92,10 +88,8 @@ class PolynomialSet(object):
     def get_embedded_degree(self):
         return self.embedded_degree
 
-    def get_dmats(self):
-        if len(self.dmats) == 0:
-            self.dmats = self.expansion_set.get_dmats(self.embedded_degree)
-        return self.dmats
+    def get_dmats(self, cell=0):
+        return self.expansion_set.get_dmats(self.embedded_degree, cell=cell)
 
     def get_reference_element(self):
         return self.ref_el

--- a/FIAT/polynomial_set.py
+++ b/FIAT/polynomial_set.py
@@ -235,19 +235,22 @@ class ONSymTensorPolynomialSet(PolynomialSet):
                                                        expansion_set, coeffs)
 
 
-def make_bubbles(ref_el, degree, shape=()):
-    """Construct a polynomial set with interior bubbles up to the given degree.
+def make_bubbles(ref_el, degree, codim=0, shape=()):
+    """Construct a polynomial set with codim bubbles up to the given degree.
     """
-    dim = ref_el.get_spatial_dimension()
     poly_set = ONPolynomialSet(ref_el, degree, shape=shape, scale="L2 piola", variant="bubble")
+    entity_ids = expansions.polynomial_entity_ids(ref_el, degree, continuity="C0")
+    sd = ref_el.get_spatial_dimension()
+    dim = sd - codim
     if dim == 1:
-        # odd / even reordering
-        degrees = chain(range(dim+1, degree+1, 2), range(dim+2, degree+1, 2))
-        indices = list(degrees)
+        # Apply even / odd reordering on edge bubbles
+        indices = []
+        for entity in entity_ids[dim]:
+            ids = entity_ids[dim][entity]
+            indices.extend(ids[::2])
+            indices.extend(ids[1::2])
     else:
-        idofs = expansions.polynomial_dimension(ref_el, degree-dim-1)
-        ndofs = poly_set.get_num_members()
-        indices = list(range(ndofs-idofs, ndofs))
+        indices = list(chain(*entity_ids[dim].values()))
 
     if shape != ():
         ncomp = numpy.prod(shape)

--- a/FIAT/polynomial_set.py
+++ b/FIAT/polynomial_set.py
@@ -69,7 +69,6 @@ class PolynomialSet(object):
     def tabulate(self, pts, jet_order=0):
         """Returns the values of the polynomial set."""
         base_vals = self.expansion_set._tabulate(self.embedded_degree, pts, order=jet_order)
-
         result = {alpha: numpy.dot(self.coeffs, base_vals[alpha]) for alpha in base_vals}
         return result
 

--- a/FIAT/quadrature.py
+++ b/FIAT/quadrature.py
@@ -36,8 +36,8 @@ def map_quadrature(pts_ref, wts_ref, source_cell, target_cell, jacobian=False):
 
 class QuadratureRule(object):
     """General class that models integration over a reference element
-    as the weighted sum of a function evaluated at a set of points."""
-
+    as the weighted sum of a function evaluated at a set of points.
+    """
     def __init__(self, ref_el, pts, wts):
         if len(wts) != len(pts):
             raise ValueError("Have %d weights, but %d points" % (len(wts), len(pts)))

--- a/FIAT/quadrature_schemes.py
+++ b/FIAT/quadrature_schemes.py
@@ -30,13 +30,13 @@ Background on the schemes:
 # NumPy
 import numpy
 
+from FIAT.macro import MacroQuadratureRule
 from FIAT.quadrature import (QuadratureRule, make_quadrature,
                              make_tensor_product_quadrature, map_quadrature)
 # FIAT
 from FIAT.reference_element import (HEXAHEDRON, QUADRILATERAL, TENSORPRODUCT,
                                     TETRAHEDRON, TRIANGLE, UFCTetrahedron,
                                     UFCTriangle, symmetric_simplex)
-from FIAT.macro import MacroQuadratureRule
 
 
 def create_quadrature(ref_el, degree, scheme="default"):
@@ -49,7 +49,7 @@ def create_quadrature(ref_el, degree, scheme="default"):
     Gauss scheme on simplices.  On tensor-product cells, it is a
     tensor-product quadrature rule of the subcells.
 
-    :arg cell: The FIAT cell to create the quadrature for.
+    :arg ref_el: The FIAT cell to create the quadrature for.
     :arg degree: The degree of polynomial that the rule should
         integrate exactly.
     """

--- a/FIAT/quadrature_schemes.py
+++ b/FIAT/quadrature_schemes.py
@@ -54,9 +54,9 @@ def create_quadrature(ref_el, degree, scheme="default"):
         integrate exactly.
     """
     if ref_el.is_macrocell():
-        sd = ref_el.get_spatial_dimension()
-        cell = ref_el.construct_subelement(sd)
-        Q_ref = create_quadrature(cell, degree, scheme=scheme)
+        dimension = ref_el.get_dimension()
+        sub_el = ref_el.construct_subelement(dimension)
+        Q_ref = create_quadrature(sub_el, degree, scheme=scheme)
         return MacroQuadratureRule(ref_el, Q_ref)
 
     if ref_el.get_shape() == TENSORPRODUCT:

--- a/FIAT/reference_element.py
+++ b/FIAT/reference_element.py
@@ -1101,6 +1101,18 @@ class TensorProductCell(Cell):
         """Return the map indicating whether each possible cell orientation causes reflection (``1``) or not (``0``)."""
         return make_cell_orientation_reflection_map_tensorproduct(self.cells)
 
+    def __gt__(self, other):
+        return all(a > b for a, b in zip(self.cells, other.cells))
+
+    def __lt__(self, other):
+        return all(a < b for a, b in zip(self.cells, other.cells))
+
+    def __ge__(self, other):
+        return all(a >= b for a, b in zip(self.cells, other.cells))
+
+    def __le__(self, other):
+        return all(a <= b for a, b in zip(self.cells, other.cells))
+
 
 class UFCQuadrilateral(Cell):
     r"""This is the reference quadrilateral with vertices

--- a/FIAT/reference_element.py
+++ b/FIAT/reference_element.py
@@ -249,6 +249,9 @@ class Cell(object):
         """Return the map indicating whether each possible cell orientation causes reflection (``1``) or not (``0``)."""
         raise NotImplementedError("Should be implemented in a subclass.")
 
+    def is_simplex(self):
+        return False
+
     def is_macrocell(self):
         return False
 
@@ -539,6 +542,9 @@ class Simplex(SimplicialComplex):
 
     o = (1 * 2!) + (1 * 1!) + (0 * 0!) = 3
     """
+    def is_simplex(self):
+        return True
+
     def symmetry_group_size(self, dim):
         return numpy.math.factorial(dim + 1)
 

--- a/FIAT/reference_element.py
+++ b/FIAT/reference_element.py
@@ -1252,6 +1252,18 @@ class UFCQuadrilateral(Cell):
         """Return the map indicating whether each possible cell orientation causes reflection (``1``) or not (``0``)."""
         return self.product.cell_orientation_reflection_map()
 
+    def __gt__(self, other):
+        return self.product > other
+
+    def __lt__(self, other):
+        return self.product < other
+
+    def __ge__(self, other):
+        return self.product >= other
+
+    def __le__(self, other):
+        return self.product <= other
+
 
 class UFCHexahedron(Cell):
     """This is the reference hexahedron with vertices
@@ -1344,6 +1356,18 @@ class UFCHexahedron(Cell):
     def cell_orientation_reflection_map(self):
         """Return the map indicating whether each possible cell orientation causes reflection (``1``) or not (``0``)."""
         return self.product.cell_orientation_reflection_map()
+
+    def __gt__(self, other):
+        return self.product > other
+
+    def __lt__(self, other):
+        return self.product < other
+
+    def __ge__(self, other):
+        return self.product >= other
+
+    def __le__(self, other):
+        return self.product <= other
 
 
 def make_affine_mapping(xs, ys):

--- a/FIAT/reference_element.py
+++ b/FIAT/reference_element.py
@@ -269,6 +269,7 @@ class Cell(object):
         return False
 
     def get_parent(self):
+        """Return the parent cell if this cell is a split and None otherwise."""
         return None
 
     def __gt__(self, other):

--- a/FIAT/reference_element.py
+++ b/FIAT/reference_element.py
@@ -78,11 +78,14 @@ def make_lattice(verts, n, interior=0, variant=None):
     and interior = 0, this function will return the vertices and
     midpoint, but with interior = 1, it will only return the
     midpoint."""
-    if variant is None or variant == "equispaced":
-        variant = "equi"
-    elif variant == "gll":
-        variant = "lgl"
-    family = _decode_family(variant)
+    if variant is None:
+        variant = "equispaced"
+    recursivenodes_families = {
+        "equispaced": "equi",
+        "equispaced_interior": "equi_interior",
+        "gll": "lgl"}
+    family = recursivenodes_families.get(variant, variant)
+    family = _decode_family(family)
     D = len(verts)
     X = numpy.array(verts)
     get_point = lambda alpha: tuple(numpy.dot(_recursive(D - 1, n, alpha, family), X))

--- a/FIAT/reference_element.py
+++ b/FIAT/reference_element.py
@@ -1101,17 +1101,25 @@ class TensorProductCell(Cell):
         """Return the map indicating whether each possible cell orientation causes reflection (``1``) or not (``0``)."""
         return make_cell_orientation_reflection_map_tensorproduct(self.cells)
 
+    def compare(self, op, other):
+        if hasattr(other, "product"):
+            other = other.product
+        if isinstance(other, type(self)):
+            return all(op(a, b) for a, b in zip(self.cells, other.cells))
+        else:
+            return op(self, other)
+
     def __gt__(self, other):
-        return all(a > b for a, b in zip(self.cells, other.cells))
+        return self.compare(operator.gt, other)
 
     def __lt__(self, other):
-        return all(a < b for a, b in zip(self.cells, other.cells))
+        return self.compare(operator.lt, other)
 
     def __ge__(self, other):
-        return all(a >= b for a, b in zip(self.cells, other.cells))
+        return self.compare(operator.ge, other)
 
     def __le__(self, other):
-        return all(a <= b for a, b in zip(self.cells, other.cells))
+        return self.compare(operator.le, other)
 
 
 class UFCQuadrilateral(Cell):

--- a/FIAT/reference_element.py
+++ b/FIAT/reference_element.py
@@ -255,6 +255,18 @@ class Cell(object):
     def get_parent(self):
         return None
 
+    def __gt__(self, other):
+        return self.get_parent() == other
+
+    def __lt__(self, other):
+        return self == other.get_parent()
+
+    def __ge__(self, other):
+        return self > other or self == other
+
+    def __le__(self, other):
+        return self < other or self == other
+
 
 class SimplicialComplex(Cell):
     r"""Abstract class for a simplicial complex.

--- a/FIAT/reference_element.py
+++ b/FIAT/reference_element.py
@@ -1580,4 +1580,4 @@ def max_complex(complexes):
     if all(max_cell >= b for b in complexes):
         return max_cell
     else:
-        return None
+        raise ValueError("Cannot find the maximal complex")

--- a/FIAT/reference_element.py
+++ b/FIAT/reference_element.py
@@ -234,6 +234,16 @@ class Cell(object):
         """
         raise NotImplementedError("Should be implemented in a subclass.")
 
+    def construct_subcomplex(self, dimension):
+        """Constructs the reference subcomplex of the parent cell subentity
+        specified by subcomplex dimension.
+
+        :arg dimension: `tuple` for tensor product cells, `int` otherwise
+        """
+        if self.get_parent() is None:
+            return self.construct_subelement(dimension)
+        raise NotImplementedError("Should be implemented in a subclass.")
+
     def get_entity_transform(self, dim, entity_i):
         """Returns a mapping of point coordinates from the
         `entity_i`-th subentity of dimension `dim` to the cell.
@@ -992,6 +1002,15 @@ class TensorProductCell(Cell):
         :arg dimension: dimension in each "direction" (tuple)
         """
         return TensorProductCell(*[c.construct_subelement(d)
+                                   for c, d in zip(self.cells, dimension)])
+
+    def construct_subcomplex(self, dimension):
+        """Constructs the reference subcomplex of the parent cell subentity
+        specified by subcomplex dimension.
+
+        :arg dimension: dimension in each "direction" (tuple)
+        """
+        return TensorProductCell(*[c.construct_subcomplex(d)
                                    for c, d in zip(self.cells, dimension)])
 
     def get_entity_transform(self, dim, entity_i):

--- a/FIAT/reference_element.py
+++ b/FIAT/reference_element.py
@@ -282,18 +282,16 @@ class SimplicialComplex(Cell):
         # case.
         cell = next(k for k, facets in enumerate(self.connectivity[(sd, sd-1)])
                     if facet_i in facets)
-        vertices = self.get_vertices_of_subcomplex(t[sd][cell])
+        verts = numpy.asarray(self.get_vertices_of_subcomplex(t[sd][cell]))
 
         # Interval case
         if self.get_shape() == LINE:
-            verts = numpy.asarray(vertices)
             v_i, = self.get_topology()[0][facet_i]
             n = verts[v_i] - verts[[1, 0][v_i]]
             return n / numpy.linalg.norm(n)
 
         # vectors from vertex 0 to each other vertex.
-        vert_vecs = numpy.asarray(vertices)
-        vert_vecs_from_v0 = vert_vecs[1:, :] - vert_vecs[:1, :]
+        vert_vecs_from_v0 = verts[1:, :] - verts[:1, :]
 
         (u, s, _) = numpy.linalg.svd(vert_vecs_from_v0)
         rank = len([si for si in s if si > 1.e-10])
@@ -306,7 +304,7 @@ class SimplicialComplex(Cell):
 
         # now I find everything normal to the facet.
         vcf = numpy.asarray(vert_coords_of_facet)
-        facet_span = vcf[1:, :] - vcf[0][None, :]
+        facet_span = vcf[1:, :] - vcf[:1, :]
         (_, sf, vft) = numpy.linalg.svd(facet_span)
 
         # now get the null space from vft

--- a/FIAT/reference_element.py
+++ b/FIAT/reference_element.py
@@ -280,10 +280,9 @@ class SimplicialComplex(Cell):
         # Find a subcell of which facet_i is on the boundary
         # Note: this is trivial and vastly overengineered for the single-cell
         # case.
-        for k, facets in enumerate(self.connectivity[(sd, sd-1)]):
-            if facet_i in facets:
-                break
-        vertices = self.get_vertices_of_subcomplex(t[sd][k])
+        cell = next(k for k, facets in enumerate(self.connectivity[(sd, sd-1)])
+                    if facet_i in facets)
+        vertices = self.get_vertices_of_subcomplex(t[sd][cell])
 
         # Interval case
         if self.get_shape() == LINE:
@@ -294,7 +293,7 @@ class SimplicialComplex(Cell):
 
         # vectors from vertex 0 to each other vertex.
         vert_vecs = numpy.asarray(vertices)
-        vert_vecs_from_v0 = vert_vecs[1:, :] - vert_vecs[0][None, :]
+        vert_vecs_from_v0 = vert_vecs[1:, :] - vert_vecs[:1, :]
 
         (u, s, _) = numpy.linalg.svd(vert_vecs_from_v0)
         rank = len([si for si in s if si > 1.e-10])
@@ -328,7 +327,7 @@ class SimplicialComplex(Cell):
         nfoo = foo[:, 0]
 
         # what is the vertex not in the facet?
-        verts_set = set(t[sd][k])
+        verts_set = set(t[sd][cell])
         verts_facet = set(t[sd - 1][facet_i])
         verts_diff = verts_set.difference(verts_facet)
         if len(verts_diff) != 1:

--- a/FIAT/reference_element.py
+++ b/FIAT/reference_element.py
@@ -298,7 +298,7 @@ class SimplicialComplex(Cell):
 
         super(SimplicialComplex, self).__init__(shape, vertices, topology)
 
-    def compute_normal(self, facet_i):
+    def compute_normal(self, facet_i, cell=None):
         """Returns the unit normal vector to facet i of codimension 1."""
 
         t = self.get_topology()
@@ -308,13 +308,13 @@ class SimplicialComplex(Cell):
         # Find a subcell of which facet_i is on the boundary
         # Note: this is trivial and vastly overengineered for the single-cell
         # case.
-        cell = next(k for k, facets in enumerate(self.connectivity[(sd, sd-1)])
-                    if facet_i in facets)
+        if cell is None:
+            cell = next(k for k, facets in enumerate(self.connectivity[(sd, sd-1)])
+                        if facet_i in facets)
         verts = numpy.asarray(self.get_vertices_of_subcomplex(t[sd][cell]))
-
         # Interval case
         if self.get_shape() == LINE:
-            v_i, = self.get_topology()[0][facet_i]
+            v_i = t[1][cell].index(t[0][facet_i][0])
             n = verts[v_i] - verts[[1, 0][v_i]]
             return n / numpy.linalg.norm(n)
 

--- a/FIAT/reference_element.py
+++ b/FIAT/reference_element.py
@@ -124,7 +124,7 @@ class Cell(object):
     """Abstract class for a reference cell.  Provides accessors for
     geometry (vertex coordinates) as well as topology (orderings of
     vertices that make up edges, facecs, etc."""
-    def __init__(self, shape, vertices, topology, parent=None):
+    def __init__(self, shape, vertices, topology):
         """The constructor takes a shape code, the physical vertices expressed
         as a list of tuples of numbers, and the topology of a cell.
 
@@ -135,7 +135,6 @@ class Cell(object):
         self.shape = shape
         self.vertices = vertices
         self.topology = topology
-        self.parent = parent
 
         # Given the topology, work out for each entity in the cell,
         # which other entities it contains.
@@ -253,20 +252,23 @@ class Cell(object):
     def is_macrocell(self):
         return False
 
+    def get_parent(self):
+        return None
+
 
 class SimplicialComplex(Cell):
     r"""Abstract class for a simplicial complex.
 
     This consists of list of vertex locations and a topology map defining facets.
     """
-    def __init__(self, shape, vertices, topology, parent=None):
+    def __init__(self, shape, vertices, topology):
         # Make sure that every facet has the right number of vertices to be
         # a simplex.
         for dim in topology:
             for entity in topology[dim]:
                 assert len(topology[dim][entity]) == dim + 1
 
-        super(SimplicialComplex, self).__init__(shape, vertices, topology, parent=parent)
+        super(SimplicialComplex, self).__init__(shape, vertices, topology)
 
     def compute_normal(self, facet_i):
         """Returns the unit normal vector to facet i of codimension 1."""

--- a/test/regression/test_regression.py
+++ b/test/regression/test_regression.py
@@ -84,7 +84,7 @@ def test_polynomials():
             ref_el=reference_element.DefaultTetrahedron(),
             degree=3
         )
-        return ps.dmats
+        return ps.get_dmats()
 
     # Try reading reference values
     filename = os.path.join(ref_path, "reference-polynomials.json")
@@ -102,7 +102,7 @@ def test_polynomials_1D():
             ref_el=reference_element.DefaultLine(),
             degree=3
         )
-        return ps.dmats
+        return ps.get_dmats()
 
     # Try reading reference values
     filename = os.path.join(ref_path, "reference-polynomials_1D.json")

--- a/test/unit/test_fiat.py
+++ b/test/unit/test_fiat.py
@@ -604,49 +604,6 @@ def test_expansion_values(dim):
 
 
 @pytest.mark.parametrize('cell', [I, T, S])
-def test_make_bubbles(cell):
-    from FIAT.quadrature_schemes import create_quadrature
-    from FIAT.expansions import polynomial_dimension
-    from FIAT.polynomial_set import make_bubbles, PolynomialSet, ONPolynomialSet
-
-    degree = 10
-    B = make_bubbles(cell, degree)
-
-    # basic tests
-    sd = cell.get_spatial_dimension()
-    assert isinstance(B, PolynomialSet)
-    assert B.degree == degree
-    assert B.get_num_members() == polynomial_dimension(cell, degree - sd - 1)
-
-    # test values on the boundary
-    top = cell.get_topology()
-    points = []
-    for dim in range(len(top)-1):
-        for entity in range(len(top[dim])):
-            points.extend(cell.make_points(dim, entity, degree))
-    values = B.tabulate(points)[(0,) * sd]
-    assert np.allclose(values, 0, atol=1E-12)
-
-    # test linear independence
-    m = B.get_num_members()
-    points = cell.make_points(sd, 0, degree)
-    values = B.tabulate(points)[(0,) * sd]
-    assert values.shape == (m, m)
-    assert np.linalg.matrix_rank(values.T, tol=1E-12) == m
-
-    # test that B does not have components in span(P_{degree+2} \ P_{degree})
-    P = ONPolynomialSet(cell, degree + 2)
-    P = P.take(list(range(polynomial_dimension(cell, degree),
-                          P.get_num_members())))
-
-    Q = create_quadrature(cell, P.degree + B.degree)
-    qpts, qwts = Q.get_points(), Q.get_weights()
-    P_at_qpts = P.tabulate(qpts)[(0,) * sd]
-    B_at_qpts = B.tabulate(qpts)[(0,) * sd]
-    assert np.allclose(np.dot(np.multiply(P_at_qpts, qwts), B_at_qpts.T), 0.0)
-
-
-@pytest.mark.parametrize('cell', [I, T, S])
 def test_bubble_duality(cell):
     from FIAT.polynomial_set import make_bubbles
     from FIAT.quadrature_schemes import create_quadrature

--- a/test/unit/test_hct.py
+++ b/test/unit/test_hct.py
@@ -1,0 +1,33 @@
+import pytest
+import numpy
+
+from FIAT import HsiehCloughTocher as HCT
+from FIAT.reference_element import ufc_simplex, make_lattice
+from FIAT.functional import PointEvaluation
+
+
+@pytest.fixture
+def cell():
+    return ufc_simplex(2)
+
+
+@pytest.mark.parametrize("reduced", (False, True))
+def test_hct_constant(cell, reduced):
+    # Test that bfs associated with point evaluation sum up to 1
+    fe = HCT(cell, reduced=reduced)
+
+    pts = make_lattice(cell.get_vertices(), 3)
+    tab = fe.tabulate(2, pts)
+
+    coefs = numpy.zeros((fe.space_dimension(),))
+    nodes = fe.dual_basis()
+    entity_dofs = fe.entity_dofs()
+    for v in entity_dofs[0]:
+        for k in entity_dofs[0][v]:
+            if isinstance(nodes[k], PointEvaluation):
+                coefs[k] = 1.0
+
+    for alpha in tab:
+        expected = 1 if sum(alpha) == 0 else 0
+        vals = numpy.dot(coefs, tab[alpha])
+        assert numpy.allclose(vals, expected)

--- a/test/unit/test_macro.py
+++ b/test/unit/test_macro.py
@@ -2,7 +2,7 @@ import math
 import numpy
 import pytest
 from FIAT import DiscontinuousLagrange, Lagrange, Legendre, P0
-from FIAT.macro import AlfeldSplit, IsoSplit
+from FIAT.macro import AlfeldSplit, IsoSplit, C1PolynomialSet
 from FIAT.quadrature_schemes import create_quadrature
 from FIAT.reference_element import ufc_simplex
 from FIAT.expansions import polynomial_entity_ids, polynomial_cell_node_map
@@ -280,3 +280,10 @@ def test_macro_expansion(cell, split, variant, degree):
         indices = numpy.ix_(ibfs, ipts)
         for alpha in values:
             assert numpy.allclose(cell_values[alpha], values[alpha][indices])
+
+
+def test_C1_basis(cell):
+    degree = 3
+    ref_el = AlfeldSplit(cell)
+    P = C1PolynomialSet(ref_el, degree)
+    print(P.expansion_set.get_num_members(degree), P.get_num_members())

--- a/test/unit/test_macro.py
+++ b/test/unit/test_macro.py
@@ -118,8 +118,8 @@ def test_macro_lagrange(variant, degree, split, cell):
         for entity in sorted(top[dim]):
             pts.extend(ref_el.make_points(dim, entity, degree, variant=variant))
 
-    phis = fe.tabulate(0, pts)[(0,)*sd]
-    assert numpy.allclose(phis, numpy.eye(fe.space_dimension()))
+    phis = fe.tabulate(2, pts)
+    assert numpy.allclose(phis[(0,)*sd], numpy.eye(fe.space_dimension()))
 
     # Test that we can reproduce the Vandermonde matrix by tabulating the expansion set
     U = poly_set.get_expansion_set()

--- a/test/unit/test_macro.py
+++ b/test/unit/test_macro.py
@@ -7,7 +7,7 @@ from FIAT.quadrature_schemes import create_quadrature
 from FIAT.reference_element import ufc_simplex
 from FIAT.expansions import polynomial_entity_ids, polynomial_cell_node_map
 from FIAT.polynomial_set import make_bubbles, PolynomialSet, ONPolynomialSet
-from FIAT.hsieh_clough_tocher import HsiehCloughTocher
+from FIAT.hct import HsiehCloughTocher
 
 
 @pytest.fixture(params=("I", "T", "S"))

--- a/test/unit/test_macro.py
+++ b/test/unit/test_macro.py
@@ -7,6 +7,7 @@ from FIAT.quadrature_schemes import create_quadrature
 from FIAT.reference_element import ufc_simplex
 from FIAT.expansions import polynomial_entity_ids, polynomial_cell_node_map
 from FIAT.polynomial_set import make_bubbles, PolynomialSet, ONPolynomialSet
+from FIAT.hsieh_clough_tocher import HsiehCloughTocher
 
 
 @pytest.fixture(params=("I", "T", "S"))
@@ -287,3 +288,25 @@ def test_C1_basis(cell):
     ref_el = AlfeldSplit(cell)
     P = C1PolynomialSet(ref_el, degree)
     print(P.expansion_set.get_num_members(degree), P.get_num_members())
+
+    child_to_parent = ref_el.get_child_to_parent()
+    sd = ref_el.get_spatial_dimension()
+    for facet in child_to_parent[sd-1]:
+        if child_to_parent[sd-1][facet][0] == sd:
+            pass
+            # TODO
+
+
+def test_HCT():
+    # FIXME move this test to its own file
+    ref_el = ufc_simplex(2)
+    fe = HsiehCloughTocher(ref_el)
+    degree = fe.degree()
+    assert degree == 3
+    assert fe.is_macroelement()
+    assert fe.space_dimension() == 12
+
+    order = 2
+    Q = create_quadrature(ref_el, 2*(degree-order))
+    pts = Q.get_points()
+    fe.tabulate(order, pts)

--- a/test/unit/test_macro.py
+++ b/test/unit/test_macro.py
@@ -110,8 +110,6 @@ def test_macro_lagrange(variant, degree, split, cell):
     for dim in parent_top:
         assert len(entity_ids[dim]) == len(parent_top[dim])
 
-    # TODO more thorough checks on entity_ids
-
     # Test that tabulation onto lattice points gives the identity
     sd = ref_el.get_spatial_dimension()
     top = ref_el.get_topology()
@@ -127,6 +125,27 @@ def test_macro_lagrange(variant, degree, split, cell):
     U = poly_set.get_expansion_set()
     V = U.tabulate(degree, pts).T
     assert numpy.allclose(fe.V, V)
+
+
+@pytest.mark.parametrize("degree", (1, 2,))
+def test_lagrange_iso_duals(cell, degree):
+    iso = Lagrange(IsoSplit(cell), degree, variant="equispaced")
+    P2 = Lagrange(cell, 2*degree, variant="equispaced")
+
+    def get_points(fe):
+        points = []
+        for node in fe.dual_basis():
+            pt, = node.get_point_dict()
+            points.append(pt)
+        return points
+
+    assert numpy.allclose(get_points(iso), get_points(P2))
+
+    iso_ids = iso.entity_dofs()
+    P2_ids = P2.entity_dofs()
+    for dim in iso_ids:
+        for entity in iso_ids[dim]:
+            assert iso_ids[dim][entity] == P2_ids[dim][entity]
 
 
 @pytest.mark.parametrize("variant", ("gll", "Alfeld,equispaced", "gll,iso"))

--- a/test/unit/test_macro.py
+++ b/test/unit/test_macro.py
@@ -2,7 +2,7 @@ import math
 import numpy
 import pytest
 from FIAT import DiscontinuousLagrange, Lagrange, Legendre, P0
-from FIAT.macro import AlfeldSplit, IsoSplit, C1PolynomialSet
+from FIAT.macro import AlfeldSplit, IsoSplit, CkPolynomialSet
 from FIAT.quadrature_schemes import create_quadrature
 from FIAT.reference_element import ufc_simplex
 from FIAT.expansions import polynomial_entity_ids, polynomial_cell_node_map
@@ -334,7 +334,7 @@ def test_macro_expansion(cell, split, variant, degree):
 def test_C1_basis(cell):
     degree = 3
     ref_el = AlfeldSplit(cell)
-    P = C1PolynomialSet(ref_el, degree)
+    P = CkPolynomialSet(ref_el, degree)
     print(P.expansion_set.get_num_members(degree), P.get_num_members())
 
     sd = ref_el.get_spatial_dimension()

--- a/test/unit/test_macro.py
+++ b/test/unit/test_macro.py
@@ -337,6 +337,7 @@ def test_C1_basis(cell):
     P = C1PolynomialSet(ref_el, degree)
     print(P.expansion_set.get_num_members(degree), P.get_num_members())
 
-    for facet in ref_el.get_interior_facets():
+    sd = ref_el.get_spatial_dimension()
+    for facet in ref_el.get_interior_facets(sd-1):
         pass
         # TODO

--- a/test/unit/test_macro.py
+++ b/test/unit/test_macro.py
@@ -1,8 +1,7 @@
 import math
 import numpy
 import pytest
-from FIAT.hierarchical import Legendre
-from FIAT.lagrange import Lagrange
+from FIAT import DiscontinuousLagrange, Lagrange, Legendre, P0
 from FIAT.macro import AlfeldSplit, IsoSplit
 from FIAT.quadrature_schemes import create_quadrature
 from FIAT.reference_element import ufc_simplex
@@ -131,10 +130,24 @@ def test_macro_lagrange(variant, degree, split, cell):
 
 
 @pytest.mark.parametrize("variant", ("gll", "Alfeld,equispaced", "gll,iso"))
-def test_is_macro(variant):
+def test_is_macro_lagrange(variant):
     is_macro = "alfeld" in variant.lower() or "iso" in variant.lower()
 
     fe = Lagrange(ufc_simplex(2), 2, variant)
+    assert not fe.get_reference_element().is_macrocell()
+    assert fe.is_macroelement() == is_macro
+    assert fe.get_reference_complex().is_macrocell() == is_macro
+    assert fe.get_nodal_basis().get_reference_element().is_macrocell() == is_macro
+
+
+@pytest.mark.parametrize("variant", ("gl", "Alfeld,equispaced_interior", "chebyshev,iso"))
+@pytest.mark.parametrize("degree", (0, 2))
+def test_is_macro_discontinuous_lagrange(degree, variant):
+    is_macro = "alfeld" in variant.lower() or "iso" in variant.lower()
+
+    fe = DiscontinuousLagrange(ufc_simplex(2), degree, variant)
+    if degree == 0 and not is_macro:
+        assert isinstance(fe, P0)
     assert not fe.get_reference_element().is_macrocell()
     assert fe.is_macroelement() == is_macro
     assert fe.get_reference_complex().is_macrocell() == is_macro

--- a/test/unit/test_macro.py
+++ b/test/unit/test_macro.py
@@ -339,7 +339,7 @@ def test_Ck_basis(cell, order, degree, variant):
     # This breaks if we were binning points into more than one cell.
     # It suffices to tabulate on the vertices of the simplicial complex.
     A = AlfeldSplit(cell)
-    Ck = CkPolynomialSet(A, degree, order=order)
+    Ck = CkPolynomialSet(A, degree, order=order, variant=variant)
     U = Ck.get_expansion_set()
 
     sd = A.get_spatial_dimension()

--- a/test/unit/test_macro.py
+++ b/test/unit/test_macro.py
@@ -334,12 +334,9 @@ def test_macro_expansion(cell, split, variant, degree):
 def test_C1_basis(cell):
     degree = 3
     ref_el = AlfeldSplit(cell)
-    P = C1PolynomialSet(ref_el, degree, shape=(2,))
+    P = C1PolynomialSet(ref_el, degree)
     print(P.expansion_set.get_num_members(degree), P.get_num_members())
 
-    child_to_parent = ref_el.get_child_to_parent()
-    sd = ref_el.get_spatial_dimension()
-    for facet in child_to_parent[sd-1]:
-        if child_to_parent[sd-1][facet][0] == sd:
-            pass
-            # TODO
+    for facet in ref_el.get_interior_facets():
+        pass
+        # TODO

--- a/test/unit/test_macro.py
+++ b/test/unit/test_macro.py
@@ -351,7 +351,6 @@ def test_Ck_basis(cell, order, degree, variant):
     for cell in top[sd]:
         ipts = list(top[sd][cell])
         verts = A.get_vertices_of_subcomplex(top[sd][cell])
-        pts = numpy.transpose(verts)
-        Uvals = U._tabulate_on_cell(degree, pts, 0, cell=cell)[(0,)*sd]
+        Uvals = U._tabulate_on_cell(degree, verts, 0, cell=cell)[(0,)*sd]
         local_phis = numpy.dot(coeffs[:, cell_node_map[cell]], Uvals)
         assert numpy.allclose(local_phis, phis[:, ipts])

--- a/test/unit/test_macro.py
+++ b/test/unit/test_macro.py
@@ -7,6 +7,7 @@ from FIAT.quadrature_schemes import create_quadrature
 from FIAT.reference_element import ufc_simplex
 from FIAT.expansions import polynomial_entity_ids, polynomial_cell_node_map
 from FIAT.polynomial_set import make_bubbles, PolynomialSet, ONPolynomialSet
+from FIAT.barycentric_interpolation import get_lagrange_points
 
 
 @pytest.fixture(params=("I", "T", "S"))
@@ -128,14 +129,6 @@ def test_macro_lagrange(variant, degree, split, cell):
     assert numpy.allclose(fe.V, V)
 
 
-def get_lagrange_points(fe):
-    points = []
-    for node in fe.dual_basis():
-        pt, = node.get_point_dict()
-        points.append(pt)
-    return points
-
-
 def make_mass_matrix(fe, order=0):
     sd = fe.ref_el.get_spatial_dimension()
     Q = create_quadrature(fe.ref_complex, 2*fe.degree())
@@ -154,8 +147,8 @@ def test_lagrange_alfeld_duals(cell, degree, variant):
     Pk_dofs = Pk.entity_dofs()
     alfeld_dofs = alfeld.entity_dofs()
 
-    Pk_pts = numpy.asarray(get_lagrange_points(Pk))
-    alfeld_pts = numpy.asarray(get_lagrange_points(alfeld))
+    Pk_pts = numpy.asarray(get_lagrange_points(Pk.dual_basis()))
+    alfeld_pts = numpy.asarray(get_lagrange_points(alfeld.dual_basis()))
 
     sd = cell.get_dimension()
     top = cell.get_topology()
@@ -179,7 +172,7 @@ def test_lagrange_iso_duals(cell, degree):
     P2 = Lagrange(cell, 2*degree, variant="equispaced")
     iso = Lagrange(IsoSplit(cell), degree, variant="equispaced")
 
-    assert numpy.allclose(get_lagrange_points(iso), get_lagrange_points(P2))
+    assert numpy.allclose(get_lagrange_points(iso.dual_basis()), get_lagrange_points(P2.dual_basis()))
 
     P2_ids = P2.entity_dofs()
     iso_ids = iso.entity_dofs()

--- a/test/unit/test_macro.py
+++ b/test/unit/test_macro.py
@@ -1,10 +1,10 @@
 import numpy
 import pytest
-from FIAT.reference_element import ufc_simplex
-from FIAT.macro import AlfeldSplit, IsoSplit, MacroQuadratureRule
-from FIAT.quadrature_schemes import create_quadrature
-from FIAT.polynomial_set import ONPolynomialSet
 from FIAT.lagrange import Lagrange
+from FIAT.macro import AlfeldSplit, IsoSplit, MacroQuadratureRule
+from FIAT.polynomial_set import ONPolynomialSet
+from FIAT.quadrature_schemes import create_quadrature
+from FIAT.reference_element import ufc_simplex
 
 
 @pytest.fixture(params=("I", "T", "S"))

--- a/test/unit/test_macro.py
+++ b/test/unit/test_macro.py
@@ -106,7 +106,7 @@ def test_macro_lagrange(variant, degree, split, cell):
 
     # Test that parent entities are the ones exposed
     entity_ids = fe.entity_dofs()
-    parent_top = ref_el.parent.get_topology()
+    parent_top = ref_el.get_parent().get_topology()
     for dim in parent_top:
         assert len(entity_ids[dim]) == len(parent_top[dim])
 

--- a/test/unit/test_macro.py
+++ b/test/unit/test_macro.py
@@ -147,6 +147,11 @@ def test_lagrange_iso_duals(cell, degree):
         for entity in iso_ids[dim]:
             assert iso_ids[dim][entity] == P2_ids[dim][entity]
 
+    poly_set = iso.get_nodal_basis()
+    assert numpy.allclose(numpy.eye(iso.space_dimension()),
+                          numpy.dot(P2.get_dual_set().to_riesz(poly_set),
+                                    poly_set.get_coeffs().T))
+
 
 @pytest.mark.parametrize("variant", ("gll", "Alfeld,equispaced", "gll,iso"))
 def test_is_macro_lagrange(variant):

--- a/test/unit/test_macro.py
+++ b/test/unit/test_macro.py
@@ -112,11 +112,12 @@ def test_macro_lagrange(variant, degree, split, cell):
 
     # Test that tabulation onto lattice points gives the identity
     sd = ref_el.get_spatial_dimension()
-    top = ref_el.get_topology()
+    parent_to_children = ref_el.get_parent_to_children()
     pts = []
-    for dim in sorted(top):
-        for entity in sorted(top[dim]):
-            pts.extend(ref_el.make_points(dim, entity, degree, variant=variant))
+    for dim in sorted(parent_to_children):
+        for entity in sorted(parent_to_children[dim]):
+            for cdim, centity in parent_to_children[dim][entity]:
+                pts.extend(ref_el.make_points(cdim, centity, degree, variant=variant))
 
     phis = fe.tabulate(2, pts)
     assert numpy.allclose(phis[(0,)*sd], numpy.eye(fe.space_dimension()))

--- a/test/unit/test_macro.py
+++ b/test/unit/test_macro.py
@@ -331,9 +331,9 @@ def test_macro_expansion(cell, split, variant, degree):
             assert numpy.allclose(cell_values[alpha], values[alpha][indices])
 
 
+@pytest.mark.parametrize("order", (0, 1))
 @pytest.mark.parametrize("variant", (None, "bubble"))
 @pytest.mark.parametrize("degree", (1, 4))
-@pytest.mark.parametrize("order", (0, 1))
 def test_Ck_basis(cell, order, degree, variant):
     # Test that we can correctly tabulate on points on facets.
     # This breaks if we were binning points into more than one cell.
@@ -341,12 +341,11 @@ def test_Ck_basis(cell, order, degree, variant):
     A = AlfeldSplit(cell)
     Ck = CkPolynomialSet(A, degree, order=order, variant=variant)
     U = Ck.get_expansion_set()
+    cell_node_map = U.get_cell_node_map(degree)
 
     sd = A.get_spatial_dimension()
     top = A.get_topology()
     coeffs = Ck.get_coeffs()
-    coeffs = coeffs.reshape((Ck.get_num_members(), len(top[sd]), -1))
-
     phis = Ck.tabulate(A.get_vertices())[(0,)*sd]
 
     for cell in top[sd]:
@@ -354,5 +353,5 @@ def test_Ck_basis(cell, order, degree, variant):
         verts = A.get_vertices_of_subcomplex(top[sd][cell])
         pts = numpy.transpose(verts)
         Uvals, = U._tabulate_on_cell(degree, pts, 0, cell=cell)
-        local_phis = numpy.dot(coeffs[:, cell, :], Uvals)
+        local_phis = numpy.dot(coeffs[:, cell_node_map[cell]], Uvals)
         assert numpy.allclose(local_phis, phis[:, ipts])

--- a/test/unit/test_macro.py
+++ b/test/unit/test_macro.py
@@ -2,8 +2,7 @@ import numpy
 import pytest
 from FIAT.hierarchical import Legendre
 from FIAT.lagrange import Lagrange
-from FIAT.macro import AlfeldSplit, IsoSplit, MacroQuadratureRule
-from FIAT.polynomial_set import ONPolynomialSet
+from FIAT.macro import AlfeldSplit, IsoSplit
 from FIAT.quadrature_schemes import create_quadrature
 from FIAT.reference_element import ufc_simplex
 

--- a/test/unit/test_macro.py
+++ b/test/unit/test_macro.py
@@ -7,7 +7,6 @@ from FIAT.quadrature_schemes import create_quadrature
 from FIAT.reference_element import ufc_simplex
 from FIAT.expansions import polynomial_entity_ids, polynomial_cell_node_map
 from FIAT.polynomial_set import make_bubbles, PolynomialSet, ONPolynomialSet
-from FIAT.hct import HsiehCloughTocher
 
 
 @pytest.fixture(params=("I", "T", "S"))
@@ -335,7 +334,7 @@ def test_macro_expansion(cell, split, variant, degree):
 def test_C1_basis(cell):
     degree = 3
     ref_el = AlfeldSplit(cell)
-    P = C1PolynomialSet(ref_el, degree)
+    P = C1PolynomialSet(ref_el, degree, shape=(2,))
     print(P.expansion_set.get_num_members(degree), P.get_num_members())
 
     child_to_parent = ref_el.get_child_to_parent()
@@ -344,18 +343,3 @@ def test_C1_basis(cell):
         if child_to_parent[sd-1][facet][0] == sd:
             pass
             # TODO
-
-
-def test_HCT():
-    # FIXME move this test to its own file
-    ref_el = ufc_simplex(2)
-    fe = HsiehCloughTocher(ref_el)
-    degree = fe.degree()
-    assert degree == 3
-    assert fe.is_macroelement()
-    assert fe.space_dimension() == 12
-
-    order = 2
-    Q = create_quadrature(ref_el, 2*(degree-order))
-    pts = Q.get_points()
-    fe.tabulate(order, pts)

--- a/test/unit/test_macro.py
+++ b/test/unit/test_macro.py
@@ -352,6 +352,6 @@ def test_Ck_basis(cell, order, degree, variant):
         ipts = list(top[sd][cell])
         verts = A.get_vertices_of_subcomplex(top[sd][cell])
         pts = numpy.transpose(verts)
-        Uvals, = U._tabulate_on_cell(degree, pts, 0, cell=cell)
+        Uvals = U._tabulate_on_cell(degree, pts, 0, cell=cell)[(0,)*sd]
         local_phis = numpy.dot(coeffs[:, cell_node_map[cell]], Uvals)
         assert numpy.allclose(local_phis, phis[:, ipts])


### PR DESCRIPTION
Extend `Simplex` to `SimplicialComplex` with minimal changes.

Implement `SplitSimplicialComplex` and `AlfeldSplit` and `IsoSplit` subclasses, which take a parent simplex in the constructor.  

`DualSet` on a `SplitSimplicialComplex` merges the entities DOFs on the complex onto the parent entites.

`ExpansionSet` loops across subcells and does indirection to evaluate the hierarchical DG or CG basis functions.

`FiniteElement` gets a reference complex attached to in, in case we want to expose the split to define quadrature rules. `CiarletElement` will infer the reference complex from the underlying polynomial space.

`create_quadrature` returns a `MacroQuadrature` rule on macro cells.