### PR TITLE
Macro: bin points to nearest cell

### DIFF
--- a/FIAT/Sminus.py
+++ b/FIAT/Sminus.py
@@ -150,7 +150,7 @@ class TrimmedSerendipity(FiniteElement):
 
         entity_dim, entity_id = entity
         transform = self.ref_el.get_entity_transform(entity_dim, entity_id)
-        points = list(map(transform, points))
+        points = transform(points)
 
         phivals = {}
 

--- a/FIAT/SminusCurl.py
+++ b/FIAT/SminusCurl.py
@@ -131,7 +131,7 @@ class TrimmedSerendipity(FiniteElement):
 
         entity_dim, entity_id = entity
         transform = self.ref_el.get_entity_transform(entity_dim, entity_id)
-        points = list(map(transform, points))
+        points = transform(points)
 
         phivals = {}
 

--- a/FIAT/SminusDiv.py
+++ b/FIAT/SminusDiv.py
@@ -121,7 +121,7 @@ class TrimmedSerendipity(FiniteElement):
 
         entity_dim, entity_id = entity
         transform = self.ref_el.get_entity_transform(entity_dim, entity_id)
-        points = list(map(transform, points))
+        points = transform(points)
 
         phivals = {}
 

--- a/FIAT/bernstein.py
+++ b/FIAT/bernstein.py
@@ -80,7 +80,7 @@ class Bernstein(FiniteElement):
 
         entity_dim, entity_id = entity
         entity_transform = ref_el.get_entity_transform(entity_dim, entity_id)
-        cell_points = list(map(entity_transform, points))
+        cell_points = entity_transform(points)
 
         # Construct Cartesian to Barycentric coordinate mapping
         vs = numpy.asarray(ref_el.get_vertices())

--- a/FIAT/dual_set.py
+++ b/FIAT/dual_set.py
@@ -258,7 +258,7 @@ def lexsort_nodes(ref_el, nodes, entity=None, offset=0):
         for node in nodes:
             pt, = node.get_point_dict()
             pts.append(pt)
-        bary = ref_el.compute_barycentric_coordinates(pts, entity=entity)
+        bary = ref_el.compute_barycentric_coordinates(pts)
         order = list(offset + numpy.lexsort(bary.T))
     else:
         order = list(range(offset, offset + len(nodes)))

--- a/FIAT/expansions.py
+++ b/FIAT/expansions.py
@@ -672,13 +672,13 @@ def compute_cell_point_map(ref_el, pts, unique=True, tol=1E-12):
         return {cell: Ellipsis for cell in sorted(top[sd])}
 
     # The distance to the nearest cell is equal to the distance to the parent cell
-    best = ref_el.get_parent().distance_to_point_l1(pts)
+    best = ref_el.get_parent().distance_to_point_l1(pts, rescale=True)
     tol = best + tol
 
     cell_point_map = {}
     for cell in sorted(top[sd]):
         # Bin points based on l1 distance
-        pts_near_cell = ref_el.distance_to_point_l1(pts, entity=(sd, cell)) < tol
+        pts_near_cell = ref_el.distance_to_point_l1(pts, entity=(sd, cell), rescale=True) < tol
         if len(pts_near_cell.shape) == 0:
             # singleton case
             if pts_near_cell:
@@ -711,7 +711,7 @@ def compute_partition_of_unity(ref_el, pt, unique=True, tol=1E-12):
     pt = pt.reshape((sd,))
 
     # The distance to the nearest cell is equal to the distance to the parent cell
-    best = ref_el.get_parent().distance_to_point_l1(pt)
+    best = ref_el.get_parent().distance_to_point_l1(pt, rescale=True)
     tol = best + tol
 
     # Compute characteristic function of each subcell
@@ -719,7 +719,7 @@ def compute_partition_of_unity(ref_el, pt, unique=True, tol=1E-12):
     masks = []
     for cell in sorted(top[sd]):
         # Bin points based on l1 distance
-        pt_near_cell = ref_el.distance_to_point_l1(pt, entity=(sd, cell)) < tol
+        pt_near_cell = ref_el.distance_to_point_l1(pt, entity=(sd, cell), rescale=True) < tol
         masks.append(Piecewise(*otherwise, (1.0, pt_near_cell), (0.0, True)))
         if unique:
             otherwise.append((0.0, pt_near_cell))

--- a/FIAT/expansions.py
+++ b/FIAT/expansions.py
@@ -685,7 +685,7 @@ def compute_l1_distance(ref_el, points, entity=None):
     b *= h
     A *= h[:, None]
     bary = apply_mapping(A, b, points, transpose=True)
-    return 0.5 * numpy.sum(abs(bary) - bary, axis=-1)
+    return 0.5 * abs(numpy.sum(abs(bary) - bary, axis=-1))
 
 
 def compute_cell_point_map(ref_el, pts, unique=True, tol=1E-12):

--- a/FIAT/finite_element.py
+++ b/FIAT/finite_element.py
@@ -191,7 +191,7 @@ class CiarletElement(FiniteElement):
 
         entity_dim, entity_id = entity
         transform = self.ref_el.get_entity_transform(entity_dim, entity_id)
-        return self.poly_set.tabulate(list(map(transform, points)), order)
+        return self.poly_set.tabulate(transform(points), order)
 
     def value_shape(self):
         "Return the value shape of the finite element functions."
@@ -243,7 +243,7 @@ def entity_support_dofs(elem, entity_dim):
     result = {}
     for f in elem.entity_dofs()[entity_dim].keys():
         entity_transform = ref_el.get_entity_transform(entity_dim, f)
-        points = list(map(entity_transform, quad.get_points()))
+        points = entity_transform(quad.get_points())
 
         # Integrate the square of the basis functions on the facet.
         vals = elem.tabulate(0, points)[(0,) * dim]

--- a/FIAT/macro.py
+++ b/FIAT/macro.py
@@ -116,7 +116,7 @@ class SplitSimplicialComplex(SimplicialComplex):
                     # sort children lexicographically
                     pts = [tuple(numpy.average([vertices[i] for i in topology[cdim][centity]], 0))
                            for cdim, centity in children]
-                    bary = parent.compute_barycentric_coordinates(pts, entity=(dim, entity))[:, 1:]
+                    bary = parent.compute_barycentric_coordinates(pts, entity=(dim, entity))
                     order = numpy.lexsort(bary.T)
                     children = tuple(children[j] for j in order)
                 else:

--- a/FIAT/macro.py
+++ b/FIAT/macro.py
@@ -116,7 +116,7 @@ class SplitSimplicialComplex(SimplicialComplex):
                     # sort children lexicographically
                     pts = [tuple(numpy.average([vertices[i] for i in topology[cdim][centity]], 0))
                            for cdim, centity in children]
-                    bary = parent.compute_barycentric_coordinates(pts, entity=(dim, entity))
+                    bary = parent.compute_barycentric_coordinates(pts, entity=(dim, entity))[:, 1:]
                     order = numpy.lexsort(bary.T)
                     children = tuple(children[j] for j in order)
                 else:

--- a/FIAT/serendipity.py
+++ b/FIAT/serendipity.py
@@ -169,7 +169,7 @@ class Serendipity(FiniteElement):
 
         entity_dim, entity_id = entity
         transform = self.ref_el.get_entity_transform(entity_dim, entity_id)
-        points = list(map(transform, points))
+        points = transform(points)
 
         phivals = {}
         dim = self.flat_el.get_spatial_dimension()
@@ -177,7 +177,6 @@ class Serendipity(FiniteElement):
             raise NotImplementedError('no tabulate method for serendipity elements of dimension 1 or less.')
         if dim >= 4:
             raise NotImplementedError('tabulate does not support higher dimensions than 3.')
-        points = np.asarray(points)
         npoints, pointdim = points.shape
         for o in range(order + 1):
             alphas = mis(dim, o)

--- a/test/unit/test_gauss_legendre.py
+++ b/test/unit/test_gauss_legendre.py
@@ -66,7 +66,7 @@ def test_edge_dofs(dim, degree):
     for entity in edge_dofs:
         if len(edge_dofs[entity]) > 0:
             transform = s.get_entity_transform(1, entity)
-            assert np.allclose(points[edge_dofs[entity]], np.array(list(map(transform, quadrature_points))))
+            assert np.allclose(points[edge_dofs[entity]], transform(quadrature_points))
 
 
 @pytest.mark.parametrize("dim, degree", [(1, 64), (2, 16), (3, 16)])

--- a/test/unit/test_gauss_lobatto_legendre.py
+++ b/test/unit/test_gauss_lobatto_legendre.py
@@ -66,7 +66,7 @@ def test_edge_dofs(dim, degree):
     for entity in edge_dofs:
         if len(edge_dofs[entity]) > 0:
             transform = s.get_entity_transform(1, entity)
-            assert np.allclose(points[edge_dofs[entity]], np.array(list(map(transform, quadrature_points))))
+            assert np.allclose(points[edge_dofs[entity]], transform(quadrature_points))
 
 
 @pytest.mark.parametrize("dim, degree", [(1, 64), (2, 16), (3, 16)])

--- a/test/unit/test_hdivtrace.py
+++ b/test/unit/test_hdivtrace.py
@@ -46,7 +46,7 @@ def test_basis_values(dim, degree):
     for facet_id in range(dim + 1):
         # Tabulate without an entity pair given --- need to map to cell coordinates
         cell_transform = ref_el.get_entity_transform(dim - 1, facet_id)
-        cell_points = np.array(list(map(cell_transform, quadrule.pts)))
+        cell_points = cell_transform(quadrule.get_points())
         ctab = fiat_element.tabulate(0, cell_points)[(0,) * dim][nf*facet_id:nf*(facet_id + 1)]
 
         # Tabulate with entity pair provided

--- a/test/unit/test_macro.py
+++ b/test/unit/test_macro.py
@@ -43,7 +43,7 @@ def test_split_make_points(split, cell, degree, variant):
         for entity in top[i]:
             pts_entity = split_cell.make_points(i, entity, degree, variant=variant)
             mapping = split_cell.get_entity_transform(i, entity)
-            mapped_pts = list(map(mapping, pts_ref))
+            mapped_pts = mapping(pts_ref)
             assert numpy.allclose(mapped_pts, pts_entity)
 
 

--- a/test/unit/test_macro.py
+++ b/test/unit/test_macro.py
@@ -343,9 +343,7 @@ def test_Ck_basis(cell, order, degree, variant):
         assert numpy.allclose(local_phis, phis[:, ipts])
 
 
-def test_compute_l1_distance(cell):
-    from FIAT.expansions import compute_l1_distance
-
+def test_distance_to_point_l1(cell):
     A = AlfeldSplit(cell)
     dim = A.get_spatial_dimension()
     top = A.get_topology()
@@ -364,13 +362,13 @@ def test_compute_l1_distance(cell):
         pts.append(Fi + d * n)
         expected.append(d)
 
-    # the computed l1 distance agrees with the l2 distance for points in front of facets
-    parent_distance = compute_l1_distance(cell, pts)
+    # the computed L1 distance agrees with the L2 distance for points in front of facets
+    parent_distance = cell.distance_to_point_l1(pts)
     assert numpy.allclose(parent_distance, expected)
 
     # assert that the subcell measures the same distance as the parent
     for i in top[dim]:
-        subcell_distance = compute_l1_distance(A, pts, entity=(dim, i))
+        subcell_distance = A.distance_to_point_l1(pts, entity=(dim, i))
         assert numpy.isclose(subcell_distance[i], expected[i])
         assert all(subcell_distance[:i] > expected[:i])
         assert all(subcell_distance[i+1:] > expected[i+1:])

--- a/test/unit/test_macro.py
+++ b/test/unit/test_macro.py
@@ -363,12 +363,12 @@ def test_distance_to_point_l1(cell):
         expected.append(d)
 
     # the computed L1 distance agrees with the L2 distance for points in front of facets
-    parent_distance = cell.distance_to_point_l1(pts)
+    parent_distance = cell.distance_to_point_l1(pts, rescale=True)
     assert numpy.allclose(parent_distance, expected)
 
     # assert that the subcell measures the same distance as the parent
     for i in top[dim]:
-        subcell_distance = A.distance_to_point_l1(pts, entity=(dim, i))
+        subcell_distance = A.distance_to_point_l1(pts, entity=(dim, i), rescale=True)
         assert numpy.isclose(subcell_distance[i], expected[i])
         assert all(subcell_distance[:i] > expected[:i])
         assert all(subcell_distance[i+1:] > expected[i+1:])

--- a/test/unit/test_reference_element.py
+++ b/test/unit/test_reference_element.py
@@ -18,7 +18,6 @@
 import pytest
 import numpy as np
 import sys
-from math import isclose
 
 from FIAT.reference_element import UFCInterval, UFCTriangle, UFCTetrahedron
 from FIAT.reference_element import Point, TensorProductCell, UFCQuadrilateral, UFCHexahedron
@@ -394,7 +393,7 @@ def test_contains_point(cell, point, epsilon, expected):
                           (quadrilateral_x_interval, [0.0, 0.0, -1e-12], 1e-12),
                           (quadrilateral_x_interval, [0.0, 0.0, 1+1e-12], 1e-12)])
 def test_distance_to_point_l1(cell, point, expected):
-    assert isclose(cell.distance_to_point_l1(point), expected, rel_tol=1e-3)
+    assert np.isclose(cell.distance_to_point_l1(point), expected, rtol=1e-3)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Update `cell_point_map` to bin points to the nearest cell. This is required for non-nested multigrid, enabling extrapolation when the children cells fall outside the parent cell.

This PR also includes some cleanup that favors numpy over list-comprehensions.