### PR TITLE
Unify MixedElement with the new UFL interface

### DIFF
--- a/finat/ufl/finiteelementbase.py
+++ b/finat/ufl/finiteelementbase.py
@@ -143,7 +143,7 @@ class FiniteElementBase(AbstractFiniteElement):
 
     def _check_component(self, domain, i):
         """Check that component index i is valid."""
-        sh = self.value_shape(domain.geometric_dimension())
+        sh = self.reference_value_shape
         r = len(sh)
         if not (len(i) == r and all(j < k for (j, k) in zip(i, sh))):
             raise ValueError(


### PR DESCRIPTION
This is an attempt to fix #105, which is still breaking G-ADOPT, because we almost always call `is_continuous` on a `MixedElement` (https://github.com/g-adopt/g-adopt/blob/03ea2a086b325a61263b66d3415612a1c5a8d289/gadopt/utility.py#L154-L168) and hit this shortcoming.

Unfortunately, I'm not fully integrated into how all of these components interact (i.e. fiat, finat, ufl), so this is quite a surface-level fix. It looks to me as though `MixedElement` has to deviate from `FiniteElementBase` in a few places:

If a component is specified in either `is_cellwise_constant()` or `degree()`, a domain must also be provided so the component can be extracted using `extract_component()`. I've put this in as an optional keyword-only argument, but I don't think this is the best approach.

Closes #105.