### PR TITLE
Fix quadrature rule hash

### DIFF
--- a/FIAT/reference_element.py
+++ b/FIAT/reference_element.py
@@ -26,6 +26,7 @@ from itertools import chain, count, product
 from math import factorial
 
 import numpy
+from gem.utils import safe_repr
 from recursivenodes.nodes import _decode_family, _recursive
 
 from FIAT.orientation_utils import (
@@ -185,7 +186,7 @@ class Cell:
         self._split_cache = {}
 
     def __repr__(self):
-        return f"{type(self).__name__}({self.shape!r}, {self.vertices!r}, {self.topology!r})"
+        return f"{type(self).__name__}({self.shape!r}, {safe_repr(self.vertices)}, {self.topology!r})"
 
     def _key(self):
         """Hashable object key data (excluding type)."""

--- a/FIAT/reference_element.py
+++ b/FIAT/reference_element.py
@@ -126,7 +126,7 @@ def linalg_subspace_intersection(A, B):
     return U[:, :rank_c]
 
 
-class Cell(object):
+class Cell:
     """Abstract class for a reference cell.  Provides accessors for
     geometry (vertex coordinates) as well as topology (orderings of
     vertices that make up edges, faces, etc."""
@@ -183,6 +183,9 @@ class Cell(object):
 
         # Dictionary with derived cells
         self._split_cache = {}
+
+    def __repr__(self):
+        return f"{type(self).__name__}({self.shape!r}, {self.vertices!r}, {self.topology!r})"
 
     def _key(self):
         """Hashable object key data (excluding type)."""
@@ -1129,6 +1132,9 @@ class TensorProductCell(Cell):
 
         super().__init__(TENSORPRODUCT, vertices, topology)
         self.cells = tuple(cells)
+
+    def __repr__(self):
+        return f"{type(self).__name__}({self.cells!r})"
 
     def _key(self):
         return self.cells

--- a/finat/point_set.py
+++ b/finat/point_set.py
@@ -1,11 +1,12 @@
 import abc
 import hashlib
+from functools import cached_property
 from itertools import chain, product
 
 import numpy
 
 import gem
-from gem.utils import cached_property
+from gem.utils import safe_repr
 
 
 class AbstractPointSet(abc.ABC):
@@ -64,7 +65,7 @@ class PointSingleton(AbstractPointSet):
         self.point = point
 
     def __repr__(self):
-        return f"{type(self).__name__}({self.point!r})"
+        return f"{type(self).__name__}({safe_repr(self.point)})"
 
     @cached_property
     def points(self):

--- a/finat/quadrature.py
+++ b/finat/quadrature.py
@@ -126,10 +126,10 @@ class QuadratureRule(AbstractQuadratureRule):
     def __repr__(self):
         return (
             f"{type(self).__name__}("
-                f"{self.point_set!r}, "
-                f"{safe_repr(self.weights)}, "
-                f"{self.ref_el!r}, "
-                f"{self._intrinsic_orientation_permutation_map_tuple!r}"
+            f"{self.point_set!r}, "
+            f"{safe_repr(self.weights)}, "
+            f"{self.ref_el!r}, "
+            f"{self._intrinsic_orientation_permutation_map_tuple!r}"
             ")"
         )
 

--- a/finat/quadrature.py
+++ b/finat/quadrature.py
@@ -1,13 +1,13 @@
 import hashlib
 from abc import ABCMeta, abstractmethod
-from functools import reduce
+from functools import cached_property, reduce
 
 import gem
 import numpy
 from FIAT.quadrature import GaussLegendreQuadratureLineRule
 from FIAT.quadrature_schemes import create_quadrature as fiat_scheme
 from FIAT.reference_element import LINE, QUADRILATERAL, TENSORPRODUCT
-from gem.utils import cached_property
+from gem.utils import safe_repr
 
 from finat.point_set import GaussLegendrePointSet, PointSet, TensorPointSet
 
@@ -65,7 +65,7 @@ class AbstractQuadratureRule(metaclass=ABCMeta):
         return int.from_bytes(hashlib.md5(repr(self).encode()).digest(), byteorder="big")
 
     def __eq__(self, other):
-        return type(other) is type(self) and hash(other) == hash(self)
+        return type(other) is type(self) and repr(other) == repr(self)
 
     @abstractmethod
     def __repr__(self):
@@ -124,7 +124,14 @@ class QuadratureRule(AbstractQuadratureRule):
         self._intrinsic_orientation_permutation_map_tuple = io_ornt_map_tuple
 
     def __repr__(self):
-        return f"{type(self).__name__}({self.point_set!r}, {self.weights!r}, {self.ref_el!r}, {self._intrinsic_orientation_permutation_map_tuple!r})"
+        return (
+            f"{type(self).__name__}("
+                f"{self.point_set!r}, "
+                f"{safe_repr(self.weights)}, "
+                f"{self.ref_el!r}, "
+                f"{self._intrinsic_orientation_permutation_map_tuple!r}"
+            ")"
+        )
 
     @cached_property
     def point_set(self):

--- a/finat/quadrature.py
+++ b/finat/quadrature.py
@@ -1,4 +1,5 @@
-from abc import ABCMeta, abstractproperty
+import hashlib
+from abc import ABCMeta, abstractmethod
 from functools import reduce
 
 import gem
@@ -60,11 +61,23 @@ class AbstractQuadratureRule(metaclass=ABCMeta):
     """Abstract class representing a quadrature rule as point set and a
     corresponding set of weights."""
 
-    @abstractproperty
+    def __hash__(self):
+        return int.from_bytes(hashlib.md5(repr(self).encode()).digest(), byteorder="big")
+
+    def __eq__(self, other):
+        return type(other) is type(self) and hash(other) == hash(self)
+
+    @abstractmethod
+    def __repr__(self):
+        pass
+
+    @property
+    @abstractmethod
     def point_set(self):
         """Point set object representing the quadrature points."""
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def weight_expression(self):
         """GEM expression describing the weights, with the same free indices
         as the point set."""
@@ -110,6 +123,9 @@ class QuadratureRule(AbstractQuadratureRule):
         self.weights = numpy.asarray(weights)
         self._intrinsic_orientation_permutation_map_tuple = io_ornt_map_tuple
 
+    def __repr__(self):
+        return f"{type(self).__name__}({self.point_set!r}, {self.weights!r}, {self.ref_el!r}, {self._intrinsic_orientation_permutation_map_tuple!r})"
+
     @cached_property
     def point_set(self):
         pass  # set at initialisation
@@ -130,6 +146,9 @@ class TensorProductQuadratureRule(AbstractQuadratureRule):
             for factor in factors
             for m in factor._intrinsic_orientation_permutation_map_tuple
         )
+
+    def __repr__(self):
+        return f"{type(self).__name__}({self.factors!r}, {self.ref_el!r})"
 
     @cached_property
     def point_set(self):

--- a/gem/utils.py
+++ b/gem/utils.py
@@ -5,7 +5,6 @@ from functools import cached_property  # noqa: F401
 from typing import Any
 
 import numpy as np
-from ufl.constantvalue import format_float
 
 
 def groupby(iterable, key=None):
@@ -126,7 +125,9 @@ def _(num: numbers.Integral) -> str:
 
 @safe_repr.register(numbers.Real)
 def _(num: numbers.Real) -> str:
-    return format_float(num)
+    # set roundoff to half the significant figures of machine epsilon
+    precision = np.finfo(num).precision // 2
+    return "{:.{prec}}".format(num, prec=precision)
 
 
 @safe_repr.register(np.ndarray)

--- a/gem/utils.py
+++ b/gem/utils.py
@@ -125,8 +125,8 @@ def _(num: numbers.Integral) -> str:
 
 @safe_repr.register(numbers.Real)
 def _(num: numbers.Real) -> str:
-    # set roundoff to half the significant figures of machine epsilon
-    precision = np.finfo(num).precision // 2
+    # set roundoff to close-to-but-not-exactly machine epsilon
+    precision = np.finfo(num).precision - 2
     return "{:.{prec}}".format(num, prec=precision)
 
 

--- a/test/finat/test_create_fiat_element.py
+++ b/test/finat/test_create_fiat_element.py
@@ -59,6 +59,11 @@ def tensor_name(request):
                 ids=lambda x: x.cellname(),
                 scope="module")
 def ufl_A(request, tensor_name):
+    if request.param == ufl.quadrilateral:
+        if tensor_name == "DG":
+            tensor_name = "DQ"
+        elif tensor_name == "DG L2":
+            tensor_name = "DQ L2"
     return finat.ufl.FiniteElement(tensor_name, request.param, 1)
 
 

--- a/test/finat/test_quadrature.py
+++ b/test/finat/test_quadrature.py
@@ -1,0 +1,19 @@
+import pytest
+
+from FIAT import ufc_cell
+from finat.quadrature import make_quadrature
+
+
+@pytest.mark.parametrize(
+    "cell_name",
+    ["interval", "triangle", "interval * interval", "triangle * interval"]
+)
+def test_quadrature_rules_are_hashable(cell_name):
+    ref_cell = ufc_cell(cell_name)
+    quadrature1 = make_quadrature(ref_cell, 3)
+    quadrature2 = make_quadrature(ref_cell, 3)
+
+    assert quadrature1 is not quadrature2
+    assert hash(quadrature1) == hash(quadrature2)
+    assert repr(quadrature1) == repr(quadrature2)
+    assert quadrature1 == quadrature2


### PR DESCRIPTION
Also remove some uses of deprecated `@abstractproperty` and gives cells and point sets `repr()`s.

Necessary for https://github.com/firedrakeproject/firedrake/pull/3989