### PR TITLE
Fix single point tabulation for DG0

### DIFF
--- a/FIAT/bernstein.py
+++ b/FIAT/bernstein.py
@@ -113,7 +113,7 @@ class Bernstein(FiniteElement):
                   for o in range(order + 1)
                   for alpha in mis(dim, o)}
         for (alpha, i), vec in raw_result.items():
-            result[alpha][i] = vec
+            result[alpha][i] = vec.reshape(result[alpha].shape[1:])
         return result
 
 

--- a/FIAT/bernstein.py
+++ b/FIAT/bernstein.py
@@ -80,12 +80,16 @@ class Bernstein(FiniteElement):
         """
         # Transform points to reference cell coordinates
         ref_el = self.get_reference_element()
+        dim = ref_el.get_spatial_dimension()
         if entity is None:
             entity = (ref_el.get_spatial_dimension(), 0)
 
         entity_dim, entity_id = entity
         entity_transform = ref_el.get_entity_transform(entity_dim, entity_id)
+
+        points = numpy.asarray(points)
         cell_points = entity_transform(points)
+        cell_points = cell_points.reshape(-1, dim)
 
         # Construct Cartesian to Barycentric coordinate mapping
         vs = numpy.asarray(ref_el.get_vertices())
@@ -97,7 +101,6 @@ class Bernstein(FiniteElement):
 
         # Evaluate everything
         deg = self.degree()
-        dim = ref_el.get_spatial_dimension()
         raw_result = {(alpha, i): vec
                       for i, ks in enumerate(mis(dim + 1, deg))
                       for o in range(order + 1)
@@ -106,11 +109,11 @@ class Bernstein(FiniteElement):
         # Rearrange result
         space_dim = self.space_dimension()
         dtype = numpy.array(list(raw_result.values())).dtype
-        result = {alpha: numpy.zeros((space_dim, len(cell_points)), dtype=dtype)
+        result = {alpha: numpy.zeros((space_dim, *points.shape[:-1]), dtype=dtype)
                   for o in range(order + 1)
                   for alpha in mis(dim, o)}
         for (alpha, i), vec in raw_result.items():
-            result[alpha][i, :] = vec
+            result[alpha][i] = vec
         return result
 
 

--- a/FIAT/expansions.py
+++ b/FIAT/expansions.py
@@ -564,7 +564,7 @@ class LineExpansionSet(ExpansionSet):
         results = {}
         scale = self.get_scale(n, cell=cell) * numpy.sqrt(2 * numpy.arange(n+1) + 1)
         for k in range(order+1):
-            v = numpy.zeros((n + 1, len(xs)), xs.dtype)
+            v = numpy.zeros((n + 1, *xs.shape[:-1]), xs.dtype)
             if n >= k:
                 v[k:] = jacobi.eval_jacobi_batch(k, k, n-k, xs)
             for p in range(n + 1):

--- a/FIAT/jacobi.py
+++ b/FIAT/jacobi.py
@@ -47,18 +47,15 @@ def eval_jacobi(a, b, n, x):
 def eval_jacobi_batch(a, b, n, xs):
     """Evaluates all jacobi polynomials with weights a,b
     up to degree n.  xs is a numpy.array of points.
-    Returns a two-dimensional array of points, where the
+    Returns a two-dimensional array of tabulations, where the
     rows correspond to the Jacobi polynomials and the
     columns correspond to the points."""
-    result = numpy.zeros((n + 1, len(xs)), xs.dtype)
-    # hack to make sure AD type is propogated through
-    for ii in range(result.shape[1]):
-        result[0, ii] = 1.0 + xs[ii, 0] - xs[ii, 0]
-
-    xsnew = xs.reshape((-1,))
+    result = numpy.zeros((n + 1, *xs.shape[:-1]), xs.dtype)
+    result[0] = 1.0
 
     if n > 0:
-        result[1, :] = 0.5 * (a - b + (a + b + 2.0) * xsnew)
+        xsnew = xs.reshape((-1,))
+        result[1] = 0.5 * (a - b + (a + b + 2.0) * xsnew)
 
         apb = a + b
         for k in range(2, n + 1):
@@ -72,8 +69,8 @@ def eval_jacobi_batch(a, b, n, xs):
             a2 = a2 / a1
             a3 = a3 / a1
             a4 = a4 / a1
-            result[k, :] = (a2 + a3 * xsnew) * result[k-1, :] \
-                - a4 * result[k-2, :]
+            result[k] = (a2 + a3 * xsnew) * result[k-1] \
+                - a4 * result[k-2]
     return result
 
 

--- a/FIAT/jacobi.py
+++ b/FIAT/jacobi.py
@@ -54,7 +54,7 @@ def eval_jacobi_batch(a, b, n, xs):
     result[0] = 1.0
 
     if n > 0:
-        xsnew = xs.reshape((-1,))
+        xsnew = xs.reshape(result.shape[1:])
         result[1] = 0.5 * (a - b + (a + b + 2.0) * xsnew)
 
         apb = a + b

--- a/test/FIAT/unit/test_fiat.py
+++ b/test/FIAT/unit/test_fiat.py
@@ -28,6 +28,7 @@ from FIAT.P0 import P0                                          # noqa: F401
 from FIAT.crouzeix_raviart import CrouzeixRaviart               # noqa: F401
 from FIAT.raviart_thomas import RaviartThomas                   # noqa: F401
 from FIAT.discontinuous_raviart_thomas import DiscontinuousRaviartThomas  # noqa: F401
+from FIAT.bernstein import Bernstein  # noqa: F401
 from FIAT.brezzi_douglas_marini import BrezziDouglasMarini      # noqa: F401
 from FIAT.mixed import MixedElement
 from FIAT.nedelec import Nedelec                                # noqa: F401
@@ -627,6 +628,8 @@ def test_error_point_high_order(element):
     'DiscontinuousLagrange(T, 1)',
     'Lagrange(I, 1)',
     'Lagrange(T, 1)',
+    'Bernstein(I, 1)',
+    'Bernstein(T, 1)',
 ])
 def test_single_point_tabulation(element):
     L = eval(element)

--- a/test/FIAT/unit/test_fiat.py
+++ b/test/FIAT/unit/test_fiat.py
@@ -620,6 +620,26 @@ def test_error_point_high_order(element):
         eval(element)
 
 
+@pytest.mark.parametrize('element', [
+    'DiscontinuousLagrange(I, 0)',
+    'DiscontinuousLagrange(T, 0)',
+    'DiscontinuousLagrange(I, 1)',
+    'DiscontinuousLagrange(T, 1)',
+    'Lagrange(I, 1)',
+    'Lagrange(T, 1)',
+])
+def test_single_point_tabulation(element):
+    L = eval(element)
+    sd = L.ref_el.get_spatial_dimension()
+    point = (0.0,) * sd
+
+    T1 = L.tabulate(0, point)[(0,) * sd]
+    assert T1.shape == (L.space_dimension(),)
+
+    T2 = L.tabulate(0, [point])[(0,) * sd]
+    assert T2.shape == (L.space_dimension(), 1)
+
+
 if __name__ == '__main__':
     import os
     pytest.main(os.path.abspath(__file__))


### PR DESCRIPTION
Ensure that `element.tabulate(0, point)` returns a vector as opposed to a matrix.