### PR TITLE
Rename pypi package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "fenics-fiat"
+name = "firedrake-fiat"
 version = "2025.04.0"
 dependencies = [
   "numpy>=1.16",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "firedrake-fiat"
-version = "2025.04.0"
+version = "2025.4.0"
 dependencies = [
   "numpy>=1.16",
   "recursivenodes",


### PR DESCRIPTION
Fixes https://github.com/firedrakeproject/fiat/issues/141

I think `firedrake-fiat` is very clear, but happy to change based on popular opinion. @rckirby @pbrubeck ?

Also this definitely has to happen because we don't own `fenics-fiat` on PyPI.