### PR TITLE
Bubble Lagrange variants and multiple facet HDivTrace tabulations

### DIFF
--- a/FIAT/bubble.py
+++ b/FIAT/bubble.py
@@ -7,6 +7,7 @@
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
 from FIAT.lagrange import Lagrange
+from FIAT.hierarchical import IntegratedLegendre
 from FIAT.restricted import RestrictedElement
 from itertools import chain
 
@@ -15,7 +16,8 @@ class CodimBubble(RestrictedElement):
     """Bubbles of a certain codimension."""
 
     def __init__(self, ref_el, degree, codim, variant=None):
-        element = Lagrange(ref_el, degree, variant=variant)
+        CG = IntegratedLegendre if variant == "integral" else Lagrange
+        element = CG(ref_el, degree, variant=variant)
 
         cell_dim = ref_el.get_dimension()
         assert cell_dim == max(element.entity_dofs().keys())

--- a/FIAT/bubble.py
+++ b/FIAT/bubble.py
@@ -16,7 +16,10 @@ class CodimBubble(RestrictedElement):
     """Bubbles of a certain codimension."""
 
     def __init__(self, ref_el, degree, codim, variant=None):
-        CG = IntegratedLegendre if variant == "integral" else Lagrange
+        if variant and variant.startswith("integral"):
+            CG = IntegratedLegendre
+        else:
+            CG = Lagrange
         element = CG(ref_el, degree, variant=variant)
 
         cell_dim = ref_el.get_dimension()

--- a/FIAT/bubble.py
+++ b/FIAT/bubble.py
@@ -14,8 +14,8 @@ from itertools import chain
 class CodimBubble(RestrictedElement):
     """Bubbles of a certain codimension."""
 
-    def __init__(self, ref_el, degree, codim):
-        element = Lagrange(ref_el, degree)
+    def __init__(self, ref_el, degree, codim, variant=None):
+        element = Lagrange(ref_el, degree, variant=variant)
 
         cell_dim = ref_el.get_dimension()
         assert cell_dim == max(element.entity_dofs().keys())
@@ -29,12 +29,12 @@ class CodimBubble(RestrictedElement):
 class Bubble(CodimBubble):
     """The bubble finite element: the dofs of the Lagrange FE in the interior of the cell"""
 
-    def __init__(self, ref_el, degree):
-        super().__init__(ref_el, degree, codim=0)
+    def __init__(self, ref_el, degree, variant=None):
+        super().__init__(ref_el, degree, codim=0, variant=variant)
 
 
 class FacetBubble(CodimBubble):
     """The facet bubble finite element: the dofs of the Lagrange FE in the interior of the facets"""
 
-    def __init__(self, ref_el, degree):
-        super().__init__(ref_el, degree, codim=1)
+    def __init__(self, ref_el, degree, variant=None):
+        super().__init__(ref_el, degree, codim=1, variant=variant)

--- a/finat/element_factory.py
+++ b/finat/element_factory.py
@@ -219,7 +219,7 @@ def convert_finiteelement(element, **kwargs):
             lmbda = finat.DiscontinuousLagrange
             finat_kwargs["variant"] = kind
 
-    elif element.family() == "HDiv Trace":
+    elif element.family() in {"HDiv Trace", "Bubble", "FacetBubble"}:
         finat_kwargs["variant"] = kind
 
     elif element.variant() is not None:

--- a/finat/fiat_elements.py
+++ b/finat/fiat_elements.py
@@ -348,13 +348,13 @@ class Bernstein(ScalarFiatElement):
 
 
 class Bubble(ScalarFiatElement):
-    def __init__(self, cell, degree):
-        super().__init__(FIAT.Bubble(cell, degree))
+    def __init__(self, cell, degree, variant=None):
+        super().__init__(FIAT.Bubble(cell, degree, variant=variant))
 
 
 class FacetBubble(ScalarFiatElement):
-    def __init__(self, cell, degree):
-        super().__init__(FIAT.FacetBubble(cell, degree))
+    def __init__(self, cell, degree, variant=None):
+        super().__init__(FIAT.FacetBubble(cell, degree, variant=variant))
 
 
 class CrouzeixRaviart(ScalarFiatElement):

--- a/test/FIAT/unit/test_fiat.py
+++ b/test/FIAT/unit/test_fiat.py
@@ -59,7 +59,7 @@ from FIAT.christiansen_hu import ChristiansenHu                 # noqa: F401
 from FIAT.guzman_neilan import GuzmanNeilanFirstKindH1          # noqa: F401
 from FIAT.guzman_neilan import GuzmanNeilanSecondKindH1         # noqa: F401
 from FIAT.johnson_mercier import JohnsonMercier                 # noqa: F401
-from FIAT.bubble import Bubble
+from FIAT.bubble import Bubble, FacetBubble                     # noqa: F401
 from FIAT.enriched import EnrichedElement                       # noqa: F401
 from FIAT.nodal_enriched import NodalEnrichedElement
 from FIAT.kong_mulder_veldhuizen import KongMulderVeldhuizen    # noqa: F401
@@ -320,8 +320,15 @@ elements = [
     "Histopolation(I, 1)",
     "Histopolation(I, 2)",
     "Bubble(I, 2)",
+    "Bubble(I, 2, 'integral')",
     "Bubble(T, 3)",
+    "Bubble(T, 3, 'integral')",
     "Bubble(S, 4)",
+    "Bubble(S, 4, 'integral')",
+    "FacetBubble(T, 2)",
+    "FacetBubble(T, 2, 'integral')",
+    "FacetBubble(S, 3)",
+    "FacetBubble(S, 3, 'integral')",
     "RestrictedElement(Lagrange(I, 2), restriction_domain='facet')",
     "RestrictedElement(Lagrange(T, 2), restriction_domain='vertex')",
     "RestrictedElement(Lagrange(T, 3), restriction_domain='facet')",

--- a/test/FIAT/unit/test_hdivtrace.py
+++ b/test/FIAT/unit/test_hdivtrace.py
@@ -25,7 +25,8 @@ import numpy as np
 
 @pytest.mark.parametrize("dim", (2, 3))
 @pytest.mark.parametrize("degree", range(7))
-def test_basis_values(dim, degree):
+@pytest.mark.parametrize("variant", ("spectral", "integral"))
+def test_basis_values(dim, degree, variant):
     """Ensure that integrating simple monomials produces the expected results
     for each facet entity of the reference triangle and tetrahedron.
 
@@ -39,7 +40,7 @@ def test_basis_values(dim, degree):
 
     ref_el = ufc_simplex(dim)
     quadrule = make_quadrature(ufc_simplex(dim - 1), degree + 1)
-    fiat_element = HDivTrace(ref_el, degree)
+    fiat_element = HDivTrace(ref_el, degree, variant=variant)
     facet_element = fiat_element.dg_elements[dim - 1]
     nf = facet_element.space_dimension()
 


### PR DESCRIPTION
This PR enables general variants for `Bubble`, `FacetBubble`, and `HDivTrace`.

Additionally, it also enables `HDivTrace` to be tabulated on multiple facets at a time. The previous behaviour allowed tabulation on points defined on a cell as long as the points were on the same facet.