### PR TITLE
Remove entity permutations for non-Lagrange elements

### DIFF
--- a/FIAT/fdm_element.py
+++ b/FIAT/fdm_element.py
@@ -141,8 +141,9 @@ class FDMDual(dual_set.DualSet):
         entity_permutations = {}
         for dim in sorted(top):
             perms = make_entity_permutations_simplex(dim, len(entity_ids[dim][0]))
-            perms = {0: perms[0]}
             entity_permutations[dim] = dict.fromkeys(top[dim], perms)
+        entity_permutations = None
+
         super().__init__(nodes, ref_el, entity_ids, entity_permutations=entity_permutations)
 
 

--- a/FIAT/fdm_element.py
+++ b/FIAT/fdm_element.py
@@ -9,12 +9,10 @@
 import abc
 import numpy
 
-from FIAT import dual_set, finite_element, functional, quadrature
+from FIAT import dual_set, finite_element, functional, quadrature, P0
 from FIAT.barycentric_interpolation import LagrangePolynomialSet
 from FIAT.polynomial_set import ONPolynomialSet
 from FIAT.reference_element import LINE
-from FIAT import DiscontinuousLagrange
-from FIAT.orientation_utils import make_entity_permutations_simplex
 
 
 def sym_eig(A, B):
@@ -138,13 +136,7 @@ class FDMDual(dual_set.DualSet):
         nodes.extend(functional.IntegralMoment(ref_el, rule, f) for f in basis[idof])
         entity_ids[sd][0].extend(range(cur, len(nodes)))
 
-        entity_permutations = {}
-        for dim in sorted(top):
-            perms = make_entity_permutations_simplex(dim, len(entity_ids[dim][0]))
-            entity_permutations[dim] = dict.fromkeys(top[dim], perms)
-        entity_permutations = None
-
-        super().__init__(nodes, ref_el, entity_ids, entity_permutations=entity_permutations)
+        super().__init__(nodes, ref_el, entity_ids)
 
 
 class FDMFiniteElement(finite_element.CiarletElement):
@@ -164,7 +156,7 @@ class FDMFiniteElement(finite_element.CiarletElement):
 
     def __new__(cls, ref_el, degree):
         if cls._formdegree == 1 and degree == 0:
-            return DiscontinuousLagrange(ref_el, degree)
+            return P0(ref_el)
         return super().__new__(cls)
 
     def __init__(self, ref_el, degree):

--- a/FIAT/fdm_element.py
+++ b/FIAT/fdm_element.py
@@ -39,7 +39,8 @@ def tridiag_eig(A, B):
     numpy.reciprocal(Z, out=Z)
     numpy.multiply(numpy.sqrt(Z), V, out=V)
     numpy.multiply(V, a[:, None], out=V)
-    return Z, V
+    # Reorder by increasing eigenvalue
+    return Z[::-1], V[:, ::-1]
 
 
 class FDMDual(dual_set.DualSet):

--- a/FIAT/hierarchical.py
+++ b/FIAT/hierarchical.py
@@ -42,7 +42,6 @@ class LegendreDual(dual_set.DualSet):
         for dim in sorted(top):
             npoints = degree + 1 if dim == sd - codim else 0
             perms = make_entity_permutations_simplex(dim, npoints)
-            perms = {0: perms[0]}
             entity_permutations[dim] = dict.fromkeys(top[dim], perms)
             if npoints == 0:
                 continue
@@ -56,6 +55,7 @@ class LegendreDual(dual_set.DualSet):
                 Q_facet = FacetQuadratureRule(ref_el, dim, entity, Q_ref)
                 nodes.extend(functional.IntegralMoment(ref_el, Q_facet, phi) for phi in phis)
                 entity_ids[dim][entity] = list(range(cur, len(nodes)))
+        entity_permutations = None
 
         super().__init__(nodes, ref_el, entity_ids, entity_permutations=entity_permutations)
 
@@ -111,8 +111,9 @@ class IntegratedLegendreDual(dual_set.DualSet):
         entity_permutations = {}
         for dim in sorted(top):
             perms = make_entity_permutations_simplex(dim, degree-dim)
-            perms = {0: perms[0]}
             entity_permutations[dim] = dict.fromkeys(top[dim], perms)
+        entity_permutations = None
+
         super().__init__(nodes, ref_el, entity_ids, entity_permutations=entity_permutations)
 
 

--- a/FIAT/hierarchical.py
+++ b/FIAT/hierarchical.py
@@ -19,6 +19,8 @@ from FIAT.P0 import P0
 
 def make_dual_bubbles(ref_el, degree, codim=0, interpolant_deg=None):
     """Tabulate the L2-duals of the hierarchical C0 basis."""
+    if ref_el.get_spatial_dimension() == 0:
+        degree = 0
     if interpolant_deg is None:
         interpolant_deg = degree
     Q = create_quadrature(ref_el, degree + interpolant_deg)
@@ -82,19 +84,12 @@ class IntegratedLegendreDual(dual_set.DualSet):
         entity_ids = {dim: {entity: [] for entity in top[dim]} for dim in top}
         nodes = []
 
-        dim = 0
-        for entity in top[dim]:
-            cur = len(nodes)
-            pts = ref_el.make_points(dim, entity, degree)
-            nodes.extend(functional.PointEvaluation(ref_el, pt) for pt in pts)
-            entity_ids[dim][entity].extend(range(cur, len(nodes)))
-
         for dim in sorted(top):
-            if dim == 0 or degree - dim <= 0:
+            if degree <= dim:
                 continue
             ref_facet = symmetric_simplex(dim)
             Q_ref, Phis = make_dual_bubbles(ref_facet, degree)
-            for entity in top[dim]:
+            for entity in sorted(top[dim]):
                 cur = len(nodes)
                 Q_facet = FacetQuadratureRule(ref_el, dim, entity, Q_ref)
                 # phis must transform like a d-form to undo the measure transformation

--- a/FIAT/hierarchical.py
+++ b/FIAT/hierarchical.py
@@ -44,7 +44,7 @@ class LegendreDual(dual_set.DualSet):
 
         dim = sd - codim
         ref_facet = ref_el.construct_subelement(dim)
-        poly_set = ONPolynomialSet(ref_facet, degree)
+        poly_set = ONPolynomialSet(ref_facet, degree, scale="L2 piola")
         Q_ref = create_quadrature(ref_facet, degree + interpolant_deg)
         Phis = poly_set.tabulate(Q_ref.get_points())[(0,) * dim]
         for entity in sorted(top[dim]):

--- a/FIAT/polynomial_set.py
+++ b/FIAT/polynomial_set.py
@@ -294,15 +294,7 @@ def make_bubbles(ref_el, degree, codim=0, shape=(), scale="L2 piola"):
     entity_ids = expansions.polynomial_entity_ids(ref_el, degree, continuity="C0")
     sd = ref_el.get_spatial_dimension()
     dim = sd - codim
-    if dim == 1:
-        # Apply even / odd reordering on edge bubbles
-        indices = []
-        for entity in entity_ids[dim]:
-            ids = entity_ids[dim][entity]
-            indices.extend(ids[::2])
-            indices.extend(ids[1::2])
-    else:
-        indices = list(chain(*entity_ids[dim].values()))
+    indices = list(chain(*entity_ids[dim].values()))
 
     if shape != ():
         ncomp = numpy.prod(shape)

--- a/FIAT/polynomial_set.py
+++ b/FIAT/polynomial_set.py
@@ -291,13 +291,15 @@ def make_bubbles(ref_el, degree, codim=0, shape=(), scale="L2 piola"):
     """Construct a polynomial set with codim bubbles up to the given degree.
     """
     poly_set = ONPolynomialSet(ref_el, degree, shape=shape, scale=scale, variant="bubble")
+    if ref_el.get_spatial_dimension() == 0:
+        return poly_set
+
     entity_ids = expansions.polynomial_entity_ids(ref_el, degree, continuity="C0")
     sd = ref_el.get_spatial_dimension()
     dim = sd - codim
     indices = list(chain(*entity_ids[dim].values()))
-
     if shape != ():
-        ncomp = numpy.prod(shape)
+        ncomp = numpy.prod(shape, dtype=int)
         dimPk = poly_set.get_num_members() // ncomp
         indices = list((numpy.array(indices)[:, None] + dimPk * numpy.arange(ncomp)[None, :]).flat)
     poly_set = poly_set.take(indices)

--- a/FIAT/restricted.py
+++ b/FIAT/restricted.py
@@ -24,6 +24,7 @@ class RestrictedDualSet(DualSet):
                                          for dof in dofs if dof in indices]
         nodes = [nodes_old[i] for i in indices]
         self._dual = dual
+
         super().__init__(nodes, ref_el, entity_ids)
 
     def get_indices(self, restriction_domain, take_closure=True):
@@ -69,4 +70,4 @@ class RestrictedElement(CiarletElement):
         assert all(e_mapping == mapping_new[0] for e_mapping in mapping_new)
 
         # Call constructor of CiarletElement
-        super().__init__(poly_set, dual, 0, element.get_formdegree(), mapping_new[0])
+        super().__init__(poly_set, dual, element.degree(), element.get_formdegree(), mapping_new[0])

--- a/finat/restricted.py
+++ b/finat/restricted.py
@@ -32,10 +32,18 @@ def restrict(element, domain, take_closure):
 @restrict.register(FiatElement)
 def restrict_fiat(element, domain, take_closure):
     try:
-        return FiatElement(FIAT.RestrictedElement(element._element,
-                           restriction_domain=domain, take_closure=take_closure))
+        re = FIAT.RestrictedElement(element._element,
+                                    restriction_domain=domain,
+                                    take_closure=take_closure)
     except ValueError:
         return null_element
+
+    if element.space_dimension() == re.space_dimension():
+        # FIAT.RestrictedElement wipes out entity_permuations.
+        # In case the restriction is trivial we return the original element
+        # to avoid reconstructing the space with an undesired permutation.
+        return element
+    return FiatElement(re)
 
 
 @restrict.register(PhysicallyMappedElement)


### PR DESCRIPTION
Fixes https://github.com/firedrakeproject/firedrake/issues/4467

Also refactoring hierarchical.py and fdm_element.py

# Exposition

To deal with the orientation problem (the mapping from the reference to the physical cell is unique up to permutations of the vertices), Firedrake has two mechanisms to generate a local to global mapping. The first one is to number dofs within an entity with increasing global vertex id. This option has the advantage that one only needs to deal with a fixed ordering of the degrees of freedom for every cell, but the resulting ordering is not robust with respect to the mesh distribution. The robust alternative involves a transformation of degrees of freedom for every possible permutation of the vertices of the reference element.

The `entity_permutations` indicate how to transform degrees of freedom for each permutation of the vertices of an entity. These were wrongly cargo-culted from the `Lagrange` element to other CG/DG elements with `IntegralMoment` degrees of freedom. So here we are removing them. 

For `IntegralMoments`, the DOF transformation cannot be described by simple permutations. This is only true if the functions in the moments are preserved under the rotation symmetry group of the simplex.

The index permutation $i \to p-i$ implied by `make_entity_permutations_simplex` will only work for moments against a Bernstein basis or a Lagrange basis on symmetric points, because there holds  $\phi_{i}(x) = \phi_{p-i}(1-x)$.

This property is not satisfied by the moments in `Legendre`, `IntegratedLegendre` and the `FDMElements` where $\phi_i(x)$ is either symmetric or antisymmetric about $x=1/2$, $\phi_{i}(x) = (-1)^i \phi_{i}(1-x)$.

So if you permute the endpoints, the symmetric moments will be preserved, but there'll  be a sign flip for the antisymmetric moments. This case cannot be covered by a DOF permutation, but instead we would require a scaling factor in the transformation.