### PR TITLE
RestrictedElement: support restriction_domain=ridge

### DIFF
--- a/FIAT/dual_set.py
+++ b/FIAT/dual_set.py
@@ -216,6 +216,8 @@ class DualSet(object):
             dim = 2
         elif restriction_domain == "facet":
             dim = self.get_reference_element().get_spatial_dimension() - 1
+        elif restriction_domain == "ridge":
+            dim = self.get_reference_element().get_spatial_dimension() - 2
         else:
             raise RuntimeError("Invalid restriction domain")
 

--- a/finat/restricted.py
+++ b/finat/restricted.py
@@ -129,6 +129,8 @@ def r_to_codim(restriction, dim):
         return 0
     elif restriction == "facet":
         return 1
+    elif restriction == "ridge":
+        return 2
     elif restriction == "face":
         return dim - 2
     elif restriction == "edge":
@@ -145,6 +147,8 @@ def codim_to_r(codim, dim):
         return "interior"
     elif codim == 1:
         return "facet"
+    elif codim == 2:
+        return "ridge"
     elif d == 0:
         return "vertex"
     elif d == 1:

--- a/finat/ufl/restrictedelement.py
+++ b/finat/ufl/restrictedelement.py
@@ -14,7 +14,7 @@
 from finat.ufl.finiteelementbase import FiniteElementBase
 from ufl.sobolevspace import L2
 
-valid_restriction_domains = ("interior", "facet", "face", "edge", "vertex", "reduced")
+valid_restriction_domains = ("interior", "facet", "ridge", "face", "edge", "vertex", "reduced")
 
 
 class RestrictedElement(FiniteElementBase):


### PR DESCRIPTION
In UFL lingo `ridge` is already used to denote codim-2 facets. 