### PR TITLE
gem: disable making temporaries for VariableIndexs

### DIFF
--- a/gem/scheduling.py
+++ b/gem/scheduling.py
@@ -117,10 +117,6 @@ def handle(ops, push, decref, node):
     elif isinstance(node, gem.Zero):  # should rarely happen
         assert not node.shape
     elif isinstance(node, (gem.Indexed, gem.FlexiblyIndexed)):
-        if node.indirect_children:
-            # Do not inline;
-            # Index expression can be involved if it contains VariableIndex.
-            ops.append(impero.Evaluate(node))
         for child in itertools.chain(node.children, node.indirect_children):
             decref(child)
     elif isinstance(node, gem.IndexSum):


### PR DESCRIPTION
Required for https://github.com/firedrakeproject/firedrake/pull/4658.

https://github.com/firedrakeproject/tsfc/pull/317 attempted to use temporaries for complex index expressions involving `VariableIndex`s, but it seems it requires more work to make in-loop temporaries work, so disable making temporaries for index expressions for now.