### PR TITLE
Move MacroPolynomialSet to subclass to prevent infinite recursion errors

### DIFF
--- a/FIAT/brezzi_douglas_marini.py
+++ b/FIAT/brezzi_douglas_marini.py
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier:    LGPL-3.0-or-later
 
 from FIAT import (finite_element, functional, dual_set,
-                  polynomial_set, nedelec)
+                  polynomial_set, nedelec, macro)
 from FIAT.check_format_variant import check_format_variant
 from FIAT.quadrature_schemes import create_quadrature
 from FIAT.quadrature import FacetQuadratureRule
@@ -103,7 +103,12 @@ class BrezziDouglasMarini(finite_element.CiarletElement):
             raise Exception("BDM_k elements only valid for k >= 1")
 
         sd = ref_el.get_spatial_dimension()
-        poly_set = polynomial_set.ONPolynomialSet(ref_el, degree, (sd, ))
+        if ref_el.is_macrocell():
+            base_element = type(self)(ref_el.get_parent(), degree)
+            poly_set = macro.MacroPolynomialSet(ref_el, base_element)
+        else:
+            poly_set = polynomial_set.ONPolynomialSet(ref_el, degree, (sd, ))
+
         dual = BDMDualSet(ref_el, degree, variant, interpolant_deg)
         formdegree = sd - 1  # (n-1)-form
         super().__init__(poly_set, dual, degree, formdegree, mapping="contravariant piola")

--- a/FIAT/crouzeix_raviart.py
+++ b/FIAT/crouzeix_raviart.py
@@ -10,7 +10,7 @@
 # Last changed: 2010-01-28
 
 import numpy
-from FIAT import finite_element, polynomial_set, dual_set, functional
+from FIAT import finite_element, polynomial_set, dual_set, functional, macro
 from FIAT.check_format_variant import check_format_variant
 from FIAT.quadrature_schemes import create_quadrature
 from FIAT.quadrature import FacetQuadratureRule
@@ -88,6 +88,11 @@ class CrouzeixRaviart(finite_element.CiarletElement):
         if splitting is not None:
             ref_el = splitting(ref_el)
 
-        poly_set = polynomial_set.ONPolynomialSet(ref_el, degree)
+        if ref_el.is_macrocell():
+            base_element = type(self)(ref_el.get_parent(), degree)
+            poly_set = macro.MacroPolynomialSet(ref_el, base_element)
+        else:
+            poly_set = polynomial_set.ONPolynomialSet(ref_el, degree)
+
         dual = CrouzeixRaviartDualSet(ref_el, degree, variant, interpolant_deg)
         super().__init__(poly_set, dual, degree)

--- a/FIAT/finite_element.py
+++ b/FIAT/finite_element.py
@@ -15,7 +15,6 @@ import warnings
 from FIAT.dual_set import DualSet
 from FIAT.polynomial_set import PolynomialSet
 from FIAT.quadrature_schemes import create_quadrature
-from FIAT.macro import MacroPolynomialSet
 
 
 class FiniteElement(object):
@@ -134,11 +133,6 @@ class CiarletElement(FiniteElement):
         ref_el = dual.get_reference_element()
         ref_complex = ref_complex or poly_set.get_reference_element()
         super().__init__(ref_el, dual, order, formdegree, mapping, ref_complex)
-
-        # Tile the poly_set
-        if ref_complex.is_macrocell() and len(poly_set) > len(dual):
-            base_element = type(self)(ref_el, order)
-            poly_set = MacroPolynomialSet(ref_complex, base_element)
 
         if len(poly_set) != len(dual):
             raise ValueError(f"Dimension of function space is {len(poly_set)}, but got {len(dual)} nodes.")

--- a/FIAT/gopalakrishnan_lederer_schoberl.py
+++ b/FIAT/gopalakrishnan_lederer_schoberl.py
@@ -1,4 +1,4 @@
-from FIAT import finite_element, dual_set, polynomial_set, expansions
+from FIAT import finite_element, dual_set, polynomial_set, expansions, macro
 from FIAT.check_format_variant import check_format_variant
 from FIAT.functional import TensorBidirectionalIntegralMoment as BidirectionalMoment
 from FIAT.quadrature_schemes import create_quadrature
@@ -63,7 +63,11 @@ class GopalakrishnanLedererSchoberlSecondKind(finite_element.CiarletElement):
         if splitting is not None:
             ref_el = splitting(ref_el)
 
-        poly_set = polynomial_set.TracelessTensorPolynomialSet(ref_el, degree)
+        if ref_el.is_macrocell():
+            base_element = type(self)(ref_el.get_parent(), degree)
+            poly_set = macro.MacroPolynomialSet(ref_el, base_element)
+        else:
+            poly_set = polynomial_set.TracelessTensorPolynomialSet(ref_el, degree)
         dual = GLSDual(ref_el, degree)
         sd = ref_el.get_spatial_dimension()
         formdegree = (1, sd-1)

--- a/FIAT/hellan_herrmann_johnson.py
+++ b/FIAT/hellan_herrmann_johnson.py
@@ -8,7 +8,7 @@
 # This file is part of FIAT (https://www.fenicsproject.org)
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
-from FIAT import dual_set, finite_element, polynomial_set
+from FIAT import dual_set, finite_element, polynomial_set, macro
 from FIAT.check_format_variant import check_format_variant
 from FIAT.functional import (PointwiseInnerProductEvaluation,
                              ComponentPointEvaluation,
@@ -110,7 +110,12 @@ class HellanHerrmannJohnson(finite_element.CiarletElement):
         if splitting is not None:
             ref_el = splitting(ref_el)
 
-        poly_set = polynomial_set.ONSymTensorPolynomialSet(ref_el, degree)
+        if ref_el.is_macrocell():
+            base_element = type(self)(ref_el.get_parent(), degree)
+            poly_set = macro.MacroPolynomialSet(ref_el, base_element)
+        else:
+            poly_set = polynomial_set.ONSymTensorPolynomialSet(ref_el, degree)
+
         dual = HellanHerrmannJohnsonDual(ref_el, degree, variant, qdegree)
         sd = ref_el.get_spatial_dimension()
         formdegree = (sd-1, sd-1)

--- a/FIAT/nedelec.py
+++ b/FIAT/nedelec.py
@@ -205,7 +205,7 @@ class Nedelec(finite_element.CiarletElement):
             ref_el = splitting(ref_el)
 
         if ref_el.is_macrocell():
-            base_element = Nedelec(ref_el.get_parent(), degree)
+            base_element = type(self)(ref_el.get_parent(), degree)
             poly_set = macro.MacroPolynomialSet(ref_el, base_element)
         elif ref_el.get_spatial_dimension() == 3:
             poly_set = NedelecSpace3D(ref_el, degree)

--- a/FIAT/nedelec_second_kind.py
+++ b/FIAT/nedelec_second_kind.py
@@ -7,6 +7,7 @@
 
 import numpy
 
+from FIAT import macro
 from FIAT.finite_element import CiarletElement
 from FIAT.dual_set import DualSet
 from FIAT.polynomial_set import ONPolynomialSet
@@ -201,8 +202,13 @@ class NedelecSecondKind(CiarletElement):
 
         # Get dimension
         d = ref_el.get_spatial_dimension()
+
         # Construct polynomial basis for d-vector fields
-        Ps = ONPolynomialSet(ref_el, degree, (d, ))
+        if ref_el.is_macrocell():
+            base_element = type(self)(ref_el.get_parent(), degree)
+            poly_set = macro.MacroPolynomialSet(ref_el, base_element)
+        else:
+            poly_set = ONPolynomialSet(ref_el, degree, (d, ))
 
         # Construct dual space
         Ls = NedelecSecondKindDual(ref_el, degree, variant, interpolant_deg)
@@ -214,4 +220,4 @@ class NedelecSecondKind(CiarletElement):
         mapping = "covariant piola"
 
         # Call init of super-class
-        super().__init__(Ps, Ls, degree, formdegree, mapping=mapping)
+        super().__init__(poly_set, Ls, degree, formdegree, mapping=mapping)

--- a/FIAT/raviart_thomas.py
+++ b/FIAT/raviart_thomas.py
@@ -149,7 +149,7 @@ class RaviartThomas(finite_element.CiarletElement):
             ref_el = splitting(ref_el)
 
         if ref_el.is_macrocell():
-            base_element = RaviartThomas(ref_el.get_parent(), degree)
+            base_element = type(self)(ref_el.get_parent(), degree)
             poly_set = macro.MacroPolynomialSet(ref_el, base_element)
         else:
             poly_set = RTSpace(ref_el, degree)

--- a/FIAT/regge.py
+++ b/FIAT/regge.py
@@ -8,7 +8,7 @@
 # This file is part of FIAT (https://www.fenicsproject.org)
 #
 # SPDX-License-Identifier:    LGPL-3.0-or-later
-from FIAT import dual_set, finite_element, polynomial_set
+from FIAT import dual_set, finite_element, polynomial_set, macro
 from FIAT.check_format_variant import check_format_variant
 from FIAT.functional import (PointwiseInnerProductEvaluation,
                              TensorBidirectionalIntegralMoment as BidirectionalMoment)
@@ -69,7 +69,12 @@ class Regge(finite_element.CiarletElement):
         if splitting is not None:
             ref_el = splitting(ref_el)
 
-        poly_set = polynomial_set.ONSymTensorPolynomialSet(ref_el, degree)
+        if ref_el.is_macrocell():
+            base_element = type(self)(ref_el.get_parent(), degree)
+            poly_set = macro.MacroPolynomialSet(ref_el, base_element)
+        else:
+            poly_set = polynomial_set.ONSymTensorPolynomialSet(ref_el, degree)
+
         dual = ReggeDual(ref_el, degree, variant, qdegree)
         formdegree = (1, 1)
         mapping = "double covariant piola"


### PR DESCRIPTION
HCT(p) fails to build the supermooth C1 space for sufficiently large p (see https://github.com/firedrakeproject/firedrake/issues/4152), since finding the nullspace of the jump constraints is a very ill-posed problem. The current logic in `CiarletElement` attempts to resolve mismatching space dimension and number of degrees of freedom by assuming that we are tiling a non-macro element on a split cell with `MacroPolynomalSet`. This will trigger an infinite recursion loop when we get a dimension mismatch on a non-tiled macroelement.

This PR only instantiates `MacroPolynomalSet` within the `CiarletElement` subclasses that can be tiled.