### PR TITLE
Fall back gracefully when sum factorisation fails.

### DIFF
--- a/finat/finiteelementbase.py
+++ b/finat/finiteelementbase.py
@@ -277,7 +277,11 @@ class FiniteElementBase(metaclass=ABCMeta):
         # ignoring any shape indices to avoid hitting the sum-
         # factorisation index limit (this is a bit of a hack).
         # Really need to do a more targeted job here.
-        evaluation = gem.optimise.contraction(evaluation, shape_indices)
+        try:
+            evaluation = gem.optimise.contraction(evaluation, shape_indices)
+        except NotImplementedError as e:
+            if str(e) != "Too many indices for sum factorisation!":
+                raise
         return evaluation, basis_indices
 
     @abstractproperty


### PR DESCRIPTION
The sum factorisation implementation only works with up to 6 indices in a contraction. There are
circumstances in which an interpolation kernel can exceed this. Rather than failing in this case, we
should not sum factorise.