### PR TITLE
Optimise find_optimal_atomics

### DIFF
--- a/gem/coffee.py
+++ b/gem/coffee.py
@@ -4,7 +4,7 @@ algorithm operating on a GEM representation.
 This file is NOT for code generation as a COFFEE AST.
 """
 
-from itertools import chain
+from itertools import chain, repeat
 import logging
 
 import numpy
@@ -85,10 +85,14 @@ def find_optimal_atomics(monomials, linear_indices):
 
     atomics = tuple(dict.fromkeys(chain.from_iterable(monomial.atomics for monomial in monomials)))
 
+    # Create a list of sets of indices to avoid any hashing during the search
     monomial_atomics = [set(map(atomics.index, m.atomics)) for m in monomials]
 
+    # Precompute the cost of each atomic
+    atomic_cost = list(map(index_extent, atomics, repeat(linear_indices)))
+
     def cost(solution):
-        extent = sum(index_extent(atomics[i], linear_indices) for i in solution)
+        extent = sum(atomic_cost[i] for i in solution)
         # Prefer shorter solutions, but larger extents
         return (len(solution), -extent)
 


### PR DESCRIPTION
The sum factorization algorithm involves finding the optimal set of common subexpressions via a brute-force search. Previously, the search spent most of the time comparing sets of "atomic" `gem.Node` instances (the so-called monomials). The set comparisons were hashing the same `gem.Node` instances over and over again. Instead, we make sure that the hashing only occurs when preprocessing all unique atomics into a list, and we solve the optimisation problem using the index into that list.

We also introduce a better initial guess by recursively sorting the subset of monomials that intersect with each other.

As a benchmark, we generate code for assembling
```
from firedrake import *
from firedrake.tsfc_interface import compile_form
V = FunctionSpace(UnitTetrahedronMesh(), "JM", 1)
v = TestFunction(V)
u = TrialFunction(V)
form = (inner(u, v) + inner(div(u), div(v))) * dx
kernels = compile_form(form, "stokes", parameters={"mode": "spectral"})
```
Notice that the (div, div) term is not integrated with dx(degree=0).

Before: 143 seconds
<img width="2631" height="909" alt="image" src="https://github.com/user-attachments/assets/6c9c5a25-ffa9-4257-b28b-3ad2a1975a29" />

After: 79 seconds
<img width="2631" height="909" alt="image" src="https://github.com/user-attachments/assets/d2350232-a17d-42a9-a5ce-b9b8688aba65" />

