### PR TITLE
 Fix simplification of ComponentTensor(Indexed)

### DIFF
--- a/gem/gem.py
+++ b/gem/gem.py
@@ -875,8 +875,11 @@ class ComponentTensor(Node):
 
         # Index folding
         if isinstance(expression, Indexed):
-            if multiindex == expression.multiindex:
-                return expression.children[0]
+            child, = expression.children
+            # Simplify ComponentTensor(Indexed(child, i), i) -> child
+            # Only fold if the child does not depend on the multiindex
+            if multiindex == expression.multiindex and not (set(multiindex) & set(child.free_indices)):
+                return child
 
         self = super(ComponentTensor, cls).__new__(cls)
         self.children = (expression,)

--- a/test/gem/test_simplify.py
+++ b/test/gem/test_simplify.py
@@ -55,6 +55,22 @@ def test_componenttensor_from_indexed(A):
     assert A == gem.ComponentTensor(Aij, (i, j))
 
 
+def test_componenttensor_from_diagonal():
+    i, = gem.indices(1)
+    a = gem.Variable("a", (2,))
+    b = gem.Variable("b", (2,))
+    rows = gem.ListTensor([gem.Indexed(a, (i,)), gem.Indexed(b, (i,))])
+    # Indexing rows on its diagonal, the index is bound by the ComponentTensor
+    diagonal = gem.Indexed(rows, (i,))
+    assert gem.ComponentTensor(diagonal, (i,)).free_indices == ()
+
+    # Unrolling the trace substitutes the index in both slots
+    expr, = gem.optimise.unroll_indexsum([gem.IndexSum(diagonal, (i,))],
+                                         predicate=lambda index: True)
+    result, = gem.optimise.remove_componenttensors([expr])
+    assert result == gem.Sum(gem.Indexed(a, (0,)), gem.Indexed(b, (1,)))
+
+
 def test_indexed_transpose(A):
     i, j = gem.indices(2)
     ATij = gem.Indexed(A.T, (i, j))


### PR DESCRIPTION
## Description

GEM-side companion of https://github.com/FEniCS/ufl/pull/496

Guard an invalid index simplication of the  form `ComponentTensor(Indexed(A(i), i), i)`

`ComponentTensor(Indexed(A, i), i) -> A` only if `A` does not depend on `i`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)