### PR TITLE
Tabulate high-order expansion derivatives by recurrence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,3 +94,6 @@ When writing Python code for FIAT, maintain the ecosystem's structural and styli
 * Boolean attributes must be used to record initialization intent and state instead of probing for the presence of state built by an initialization function.
 * New code must include type hints on all function and method signatures.
 * Public-facing APIs must include properly formatted `numpydoc`-style docstrings.
+* CI enforces `pydocstyle` (see the `[pydocstyle]` section of `setup.cfg` for the active ignore list)
+  in addition to `flake8`; run `pydocstyle <changed files>` locally before finishing a change, since a
+  clean `flake8` pass does not imply a clean `pydocstyle` pass.

--- a/FIAT/expansions.py
+++ b/FIAT/expansions.py
@@ -62,6 +62,55 @@ def jacobi_factors(x, y, z, dx, dy, dz):
     return fa, fb, fc, dfa, dfb, dfc
 
 
+def _product_derivative_term(factor: object,
+                             operand: numpy.ndarray,
+                             factor_axes: tuple[int, ...],
+                             rank: int) -> numpy.ndarray:
+    """Return one Leibniz term in an ordered derivative tensor."""
+    factor = numpy.asarray(factor)
+    factor_rank = len(factor_axes)
+    operand_rank = rank - factor_rank
+    factor_index = (slice(None),) * factor_rank + (None,) * operand_rank + (Ellipsis,)
+    operand_index = (None,) * factor_rank + (Ellipsis,)
+    product = factor[factor_index] * operand[operand_index]
+
+    if rank:
+        dim = factor.shape[0] if operand_rank == 0 else operand.shape[0]
+        factor_source = {axis: source for source, axis in enumerate(factor_axes)}
+        operand_axes = tuple(axis for axis in range(rank) if axis not in factor_axes)
+        operand_source = {axis: factor_rank + source
+                          for source, axis in enumerate(operand_axes)}
+        permutation = tuple((factor_source | operand_source)[axis]
+                            for axis in range(rank))
+        product = product.transpose(permutation + tuple(range(rank, product.ndim)))
+        product = product.reshape((dim,) * rank + operand.shape[operand_rank:])
+
+    return product
+
+
+def _product_derivative(factor: object,
+                        dfactor: object | None,
+                        ddfactor: object | None,
+                        operands: list[numpy.ndarray],
+                        rank: int) -> numpy.ndarray:
+    """Differentiate a recurrence factor times a basis derivative tensor."""
+    # The Dubiner recurrence factors are linear or quadratic, so higher
+    # factor derivatives vanish and the Leibniz sum stops at order two.
+    result = _product_derivative_term(factor, operands[rank], (), rank)
+
+    if dfactor is not None and rank >= 1:
+        for axis in range(rank):
+            result += _product_derivative_term(dfactor, operands[rank-1], (axis,), rank)
+
+    if ddfactor is not None and rank >= 2:
+        for axis0 in range(rank):
+            for axis1 in range(axis0 + 1, rank):
+                result += _product_derivative_term(ddfactor, operands[rank-2],
+                                                   (axis0, axis1), rank)
+
+    return result
+
+
 def dubiner_recurrence(dim, n, order, ref_pts, Jinv, scale, variant=None):
     """Tabulate a Dubiner expansion set using the recurrence from (Kirby 2010).
 
@@ -77,8 +126,6 @@ def dubiner_recurrence(dim, n, order, ref_pts, Jinv, scale, variant=None):
 
     :returns: A tuple with tabulations of the expansion set and its derivatives.
     """
-    if order > 2:
-        raise ValueError("Higher order derivatives not supported")
     if variant not in [None, "bubble", "dual"]:
         raise ValueError(f"Invalid variant {variant}")
     if variant == "bubble":
@@ -95,7 +142,7 @@ def dubiner_recurrence(dim, n, order, ref_pts, Jinv, scale, variant=None):
     results = [numpy.zeros((num_members,) + (dim,)*k + phi0.shape[1:], dtype=phi0.dtype)
                for k in range(order+1)]
 
-    phi, dphi, ddphi = results + [None] * (2-order)
+    phi = results[0]
     phi[0] = scale
     if dim == 0 or n == 0:
         return results
@@ -127,14 +174,12 @@ def dubiner_recurrence(dim, n, order, ref_pts, Jinv, scale, variant=None):
 
             fcur = a * fa - b * fb
             phi[inext] = fcur * phi[icur]
-            if dphi is not None:
+            if order:
                 dfcur = a * dfa - b * dfb
-                dphi[inext] = phi[icur] * dfcur
-                dphi[inext] += fcur * dphi[icur]
-                if ddphi is not None:
-                    ddphi[inext] = outer(dphi[icur], dfcur)
-                    ddphi[inext] += outer(dfcur, dphi[icur])
-                    ddphi[inext] += fcur * ddphi[icur]
+                cur = [result[icur] for result in results]
+                for rank in range(1, order+1):
+                    results[rank][inext] = _product_derivative(fcur, dfcur, None,
+                                                               cur, rank)
 
             # general i by recurrence
             for i in range(1, n - sum(sub_index)):
@@ -145,26 +190,17 @@ def dubiner_recurrence(dim, n, order, ref_pts, Jinv, scale, variant=None):
                 fprev = -c * fc
                 phi[inext] = fcur * phi[icur]
                 phi[inext] += fprev * phi[iprev]
-                if dphi is None:
-                    continue
 
                 dfcur = a * dfa - b * dfb
                 dfprev = -c * dfc
-                dphi[inext] = phi[icur] * dfcur
-                dphi[inext] += phi[iprev] * dfprev
-                dphi[inext] += fcur * dphi[icur]
-                dphi[inext] += fprev * dphi[iprev]
-                if ddphi is None:
-                    continue
-
                 ddfprev = -c * ddfc
-                ddphi[inext] = phi[iprev] * ddfprev
-                ddphi[inext] += outer(dphi[icur], dfcur)
-                ddphi[inext] += outer(dfcur, dphi[icur])
-                ddphi[inext] += outer(dphi[iprev], dfprev)
-                ddphi[inext] += outer(dfprev, dphi[iprev])
-                ddphi[inext] += fcur * ddphi[icur]
-                ddphi[inext] += fprev * ddphi[iprev]
+                cur = [result[icur] for result in results]
+                prev = [result[iprev] for result in results]
+                for rank in range(1, order+1):
+                    results[rank][inext] = _product_derivative(fcur, dfcur, None,
+                                                               cur, rank)
+                    results[rank][inext] += _product_derivative(fprev, dfprev, ddfprev,
+                                                                prev, rank)
 
         # normalize
         d = codim + 1
@@ -291,7 +327,7 @@ class ExpansionSet(object):
         self.scale = scale
         self.variant = variant
         self.continuity = "C0" if variant == "bubble" else None
-        self.recurrence_order = 2
+        self.recurrence_order = math.inf
         self._dmats_cache = {}
         self._cell_node_map_cache = {}
 
@@ -353,7 +389,7 @@ class ExpansionSet(object):
         def distance(alpha, beta):
             return sum(ai != bi for ai, bi in zip(alpha, beta))
 
-        # Only use dmats if tabulate failed
+        # Use dmats only for derivatives above the configured recurrence order.
         for i in range(len(phi), order + 1):
             dmats = self.get_dmats(n, cell=cell)
             for alpha in mis(sd, i):

--- a/FIAT/expansions.py
+++ b/FIAT/expansions.py
@@ -97,25 +97,25 @@ def _product_derivative(factor: numpy.ndarray,
     # result = F * D^alpha G
     result = factor * operands[order]
 
-    if dfactor is not None and order >= 1:
+    if dfactor is not None and order >= 1 and not numpy.allclose(dfactor, 0):
         alpha_minus1 = mis(dim, order - 1)
         idx_of_minus1 = {alpha: i for i, alpha in enumerate(alpha_minus1)}
+        DF = numpy.zeros((len(alphas), *dfactor.shape[1:], len(alpha_minus1)))
         for j, alpha in enumerate(alphas):
             for d in range(dim):
                 if alpha[d] < 1:
                     continue
                 alpha_minus = list(alpha)
                 alpha_minus[d] -= 1
-                if order - 1 == 0:
-                    val = operands[0]
-                else:
-                    idx_minus = idx_of_minus1[tuple(alpha_minus)]
-                    val = operands[order-1][idx_minus]
-                result[j] += alpha[d] * dfactor[d] * val
+                i = idx_of_minus1[tuple(alpha_minus)]
+                DF[j, ..., i] += alpha[d] * dfactor[d]
+        # result += alpha * D F * D^(alpha-1) G
+        result += numpy.einsum('...k,k...->...', DF, operands[order-1])
 
-    if ddfactor is not None and order >= 2:
+    if ddfactor is not None and order >= 2 and not numpy.allclose(ddfactor, 0):
         alpha_minus2 = mis(dim, order - 2)
         idx_of_minus2 = {alpha: i for i, alpha in enumerate(alpha_minus2)}
+        DDF = numpy.zeros((len(alphas), *ddfactor.shape[2:], len(alpha_minus2)))
         for j, alpha in enumerate(alphas):
             for d1 in range(dim):
                 for d2 in range(d1, dim):
@@ -124,16 +124,14 @@ def _product_derivative(factor: numpy.ndarray,
                     alpha_minus = list(alpha)
                     alpha_minus[d1] -= 1
                     alpha_minus[d2] -= 1
-                    if order - 2 == 0:
-                        val = operands[0]
-                    else:
-                        idx_minus = idx_of_minus2[tuple(alpha_minus)]
-                        val = operands[order-2][idx_minus]
+                    i = idx_of_minus2[tuple(alpha_minus)]
                     if d1 == d2:
-                        coeff = alpha[d1] * (alpha[d1] - 1) // 2
+                        a2 = alpha[d1] * (alpha[d1] - 1) // 2
                     else:
-                        coeff = alpha[d1] * alpha[d2]
-                    result[j] += coeff * ddfactor[d1, d2] * val
+                        a2 = alpha[d1] * alpha[d2]
+                    DDF[j, ..., i] += a2 * ddfactor[d1, d2]
+        # result += alpha*(alpha-1)/2 * D^2 F * D^(alpha-2) G
+        result += numpy.einsum('i...k,k...->i...', DDF, operands[order-2])
 
     return result
 
@@ -184,7 +182,7 @@ def dubiner_recurrence(dim: int,
 
     phi0 = numpy.array([sum((ref_pts[i] - ref_pts[i] for i in range(dim)), 0.0)])
     results = [
-        numpy.zeros((num_members,) + (math.comb(dim+k-1, k),) * (k > 0) + phi0.shape[1:], dtype=phi0.dtype)
+        numpy.zeros((num_members, math.comb(dim+k-1, k), *phi0.shape[1:]), dtype=phi0.dtype)
         for k in range(order+1)
     ]
 
@@ -240,6 +238,7 @@ def dubiner_recurrence(dim: int,
                 dfcur = a * dfa - b * dfb
                 dfprev = -c * dfc
                 ddfprev = -c * ddfc
+
                 cur = [result[icur] for result in results]
                 prev = [result[iprev] for result in results]
                 deg = sum(sub_index) + 1 + i
@@ -318,7 +317,7 @@ def C0_basis(dim, n, tabulations):
 
         dofs.extend(idx(i, j, k) for k in range(1, n+1) for j in range(1, n-k+1) for i in range(2, n-j-k+1))
 
-    return tuple([phi[i] for i in dofs] for phi in tabulations)
+    return tuple(phi[dofs] for phi in tabulations)
 
 
 def xi_triangle(eta):
@@ -424,8 +423,7 @@ class ExpansionSet(object):
 
         # Pack linearly independent components into a dictionary
         result = {}
-        result[(0,) * sd] = numpy.asarray(phi[0])
-        for r in range(1, len(phi)):
+        for r in range(len(phi)):
             vr = numpy.asarray(phi[r])
             vr = vr.transpose(1, 0, *range(2, vr.ndim))
             for j, alpha in enumerate(mis(sd, r)):

--- a/FIAT/expansions.py
+++ b/FIAT/expansions.py
@@ -96,11 +96,12 @@ def _product_derivative(factor: numpy.ndarray,
 
     # result = F * D^alpha G
     result = factor * operands[order]
+    dtype = result.dtype
 
-    if dfactor is not None and order >= 1 and not numpy.allclose(dfactor, 0):
+    if dfactor is not None and order >= 1:
         alpha_minus1 = mis(dim, order - 1)
         idx_of_minus1 = {alpha: i for i, alpha in enumerate(alpha_minus1)}
-        DF = numpy.zeros((len(alphas), *dfactor.shape[1:], len(alpha_minus1)))
+        DF = numpy.zeros((len(alphas), *dfactor.shape[1:], len(alpha_minus1)), dtype=dtype)
         for j, alpha in enumerate(alphas):
             for d in range(dim):
                 if alpha[d] < 1:
@@ -112,10 +113,10 @@ def _product_derivative(factor: numpy.ndarray,
         # result += alpha * D F * D^(alpha-1) G
         result += numpy.einsum('...k,k...->...', DF, operands[order-1])
 
-    if ddfactor is not None and order >= 2 and not numpy.allclose(ddfactor, 0):
+    if ddfactor is not None and order >= 2:
         alpha_minus2 = mis(dim, order - 2)
         idx_of_minus2 = {alpha: i for i, alpha in enumerate(alpha_minus2)}
-        DDF = numpy.zeros((len(alphas), *ddfactor.shape[2:], len(alpha_minus2)))
+        DDF = numpy.zeros((len(alphas), *ddfactor.shape[2:], len(alpha_minus2)), dtype=dtype)
         for j, alpha in enumerate(alphas):
             for d1 in range(dim):
                 for d2 in range(d1, dim):
@@ -130,7 +131,7 @@ def _product_derivative(factor: numpy.ndarray,
                     else:
                         a2 = alpha[d1] * alpha[d2]
                     DDF[j, ..., i] += a2 * ddfactor[d1, d2]
-        # result += alpha*(alpha-1)/2 * D^2 F * D^(alpha-2) G
+        # result += alpha*(alpha-1) * D^2 F * D^(alpha-2) G
         result += numpy.einsum('i...k,k...->i...', DDF, operands[order-2])
 
     return result
@@ -181,8 +182,9 @@ def dubiner_recurrence(dim: int,
     dX = pad_jacobian(Jinv, pad_dim)
 
     phi0 = numpy.array([sum((ref_pts[i] - ref_pts[i] for i in range(dim)), 0.0)])
+    dtype = phi0.dtype
     results = [
-        numpy.zeros((num_members, math.comb(dim+k-1, k), *phi0.shape[1:]), dtype=phi0.dtype)
+        numpy.zeros((num_members, math.comb(dim+k-1, k), *phi0.shape[1:]), dtype=dtype)
         for k in range(order+1)
     ]
 
@@ -217,7 +219,7 @@ def dubiner_recurrence(dim: int,
                 b = 0.5 * (alpha - beta)
 
             fcur = a * fa - b * fb
-            phi[inext] = fcur * phi[icur]
+            phi[inext] = phi[icur] * fcur
             if order:
                 dfcur = a * dfa - b * dfb
                 cur = [result[icur] for result in results]
@@ -232,8 +234,8 @@ def dubiner_recurrence(dim: int,
 
                 fcur = a * fa - b * fb
                 fprev = -c * fc
-                phi[inext] = fcur * phi[icur]
-                phi[inext] += fprev * phi[iprev]
+                phi[inext] = phi[icur] * fcur
+                phi[inext] += phi[iprev] * fprev
 
                 dfcur = a * dfa - b * dfb
                 dfprev = -c * dfc

--- a/FIAT/expansions.py
+++ b/FIAT/expansions.py
@@ -63,69 +63,114 @@ def jacobi_factors(x, y, z, dx, dy, dz):
     return fa, fb, fc, dfa, dfb, dfc
 
 
-def _product_derivative_term(factor: object,
-                             operand: numpy.ndarray,
-                             factor_axes: tuple[int, ...],
-                             rank: int) -> numpy.ndarray:
-    """Return one Leibniz term in an ordered derivative tensor."""
-    factor = numpy.asarray(factor)
-    factor_rank = len(factor_axes)
-    operand_rank = rank - factor_rank
-    factor_index = (slice(None),) * factor_rank + (None,) * operand_rank + (Ellipsis,)
-    operand_index = (None,) * factor_rank + (Ellipsis,)
-    product = factor[factor_index] * operand[operand_index]
-
-    if rank:
-        dim = factor.shape[0] if operand_rank == 0 else operand.shape[0]
-        factor_source = {axis: source for source, axis in enumerate(factor_axes)}
-        operand_axes = tuple(axis for axis in range(rank) if axis not in factor_axes)
-        operand_source = {axis: factor_rank + source
-                          for source, axis in enumerate(operand_axes)}
-        permutation = tuple((factor_source | operand_source)[axis]
-                            for axis in range(rank))
-        product = product.transpose(permutation + tuple(range(rank, product.ndim)))
-        product = product.reshape((dim,) * rank + operand.shape[operand_rank:])
-
-    return product
-
-
-def _product_derivative(factor: object,
-                        dfactor: object | None,
-                        ddfactor: object | None,
+def _product_derivative(factor: numpy.ndarray,
+                        dfactor: numpy.ndarray | None,
+                        ddfactor: numpy.ndarray | None,
                         operands: list[numpy.ndarray],
-                        rank: int) -> numpy.ndarray:
-    """Differentiate a recurrence factor times a basis derivative tensor."""
-    # The Dubiner recurrence factors are linear or quadratic, so higher
-    # factor derivatives vanish and the Leibniz sum stops at order two.
-    result = _product_derivative_term(factor, operands[rank], (), rank)
+                        order: int) -> numpy.ndarray:
+    """Differentiate a recurrence factor times a basis derivative tensor.
 
-    if dfactor is not None and rank >= 1:
-        for axis in range(rank):
-            result += _product_derivative_term(dfactor, operands[rank-1], (axis,), rank)
+    Parameters
+    ----------
+    factor : numpy.ndarray
+        The recurrence factor.
+    dfactor : numpy.ndarray, optional
+        The first derivative of the recurrence factor.
+    ddfactor : numpy.ndarray, optional
+        The second derivative of the recurrence factor.
+    operands : list[numpy.ndarray]
+        List of basis derivative tensors up to order rank.
+    order : int
+        The derivative order of the output.
 
-    if ddfactor is not None and rank >= 2:
-        for axis0 in range(rank):
-            for axis1 in range(axis0 + 1, rank):
-                result += _product_derivative_term(ddfactor, operands[rank-2],
-                                                   (axis0, axis1), rank)
+    Returns
+    -------
+    numpy.ndarray
+        The differentiated product tensor of shape (len(mis(dim, rank)), num_points).
+
+    """
+    from FIAT.polynomial_set import mis
+
+    dim = dfactor.shape[0] if dfactor is not None else 0
+    alphas = mis(dim, order)
+
+    # result = F * D^alpha G
+    result = factor * operands[order]
+
+    if dfactor is not None and order >= 1:
+        alpha_minus1 = mis(dim, order - 1)
+        idx_of_minus1 = {alpha: i for i, alpha in enumerate(alpha_minus1)}
+        for j, alpha in enumerate(alphas):
+            for d in range(dim):
+                if alpha[d] < 1:
+                    continue
+                alpha_minus = list(alpha)
+                alpha_minus[d] -= 1
+                if order - 1 == 0:
+                    val = operands[0]
+                else:
+                    idx_minus = idx_of_minus1[tuple(alpha_minus)]
+                    val = operands[order-1][idx_minus]
+                result[j] += alpha[d] * dfactor[d] * val
+
+    if ddfactor is not None and order >= 2:
+        alpha_minus2 = mis(dim, order - 2)
+        idx_of_minus2 = {alpha: i for i, alpha in enumerate(alpha_minus2)}
+        for j, alpha in enumerate(alphas):
+            for d1 in range(dim):
+                for d2 in range(d1, dim):
+                    if alpha[d1] < 1 + (d1 == d2) or alpha[d2] < 1 + (d1 == d2):
+                        continue
+                    alpha_minus = list(alpha)
+                    alpha_minus[d1] -= 1
+                    alpha_minus[d2] -= 1
+                    if order - 2 == 0:
+                        val = operands[0]
+                    else:
+                        idx_minus = idx_of_minus2[tuple(alpha_minus)]
+                        val = operands[order-2][idx_minus]
+                    if d1 == d2:
+                        coeff = alpha[d1] * (alpha[d1] - 1) // 2
+                    else:
+                        coeff = alpha[d1] * alpha[d2]
+                    result[j] += coeff * ddfactor[d1, d2] * val
 
     return result
 
 
-def dubiner_recurrence(dim, n, order, ref_pts, Jinv, scale, variant=None):
+def dubiner_recurrence(dim: int,
+                       n: int,
+                       order: int,
+                       ref_pts: numpy.ndarray,
+                       Jinv: numpy.ndarray,
+                       scale: float,
+                       variant: str | None = None) -> list[numpy.ndarray]:
     """Tabulate a Dubiner expansion set using the recurrence from (Kirby 2010).
 
-    :arg dim: The spatial dimension of the simplex.
-    :arg n: The polynomial degree.
-    :arg order: The maximum order of differentiation.
-    :arg ref_pts: An ``ndarray`` with the coordinates on the default (-1, 1)^d simplex.
-    :arg Jinv: The inverse of the Jacobian of the coordinate mapping from the default simplex.
-    :arg scale: A scale factor that sets the first member of expansion set.
-    :arg variant: Choose between the default (None) orthogonal basis,
-                  'bubble' for integrated Jacobi polynomials,
-                  or 'dual' for the L2-duals of the integrated Jacobi polynomials.
+    Parameters
+    ----------
+    dim : int
+        The spatial dimension of the simplex.
+    n : int
+        The polynomial degree.
+    order : int
+        The maximum order of differentiation.
+    ref_pts : numpy.ndarray
+        An ``ndarray`` with the coordinates on the default (-1, 1)^d simplex.
+    Jinv : numpy.ndarray
+        The inverse of the Jacobian of the coordinate mapping from the default simplex.
+    scale : float
+        A scale factor that sets the first member of expansion set.
+    variant : str, optional
+        Choose between the default (None) orthogonal basis,
+        'bubble' for integrated Jacobi polynomials,
+        or 'dual' for the L2-duals of the integrated Jacobi polynomials.
 
-    :returns: A tuple with tabulations of the expansion set and its derivatives.
+    Returns
+    -------
+    list[numpy.ndarray]
+        A list of numpy arrays with tabulations of the expansion set and its derivatives.
+
     """
     if variant not in [None, "bubble", "dual"]:
         raise ValueError(f"Invalid variant {variant}")
@@ -134,14 +179,14 @@ def dubiner_recurrence(dim, n, order, ref_pts, Jinv, scale, variant=None):
 
     num_members = math.comb(n + dim, dim)
 
-    outer = lambda x, y: x[:, None, ...] * y[None, ...]
-
     pad_dim = dim + 2
     dX = pad_jacobian(Jinv, pad_dim)
 
     phi0 = numpy.array([sum((ref_pts[i] - ref_pts[i] for i in range(dim)), 0.0)])
-    results = [numpy.zeros((num_members,) + (dim,)*k + phi0.shape[1:], dtype=phi0.dtype)
-               for k in range(order+1)]
+    results = [
+        numpy.zeros((num_members,) + (math.comb(dim+k-1, k),) * (k > 0) + phi0.shape[1:], dtype=phi0.dtype)
+        for k in range(order+1)
+    ]
 
     phi = results[0]
     phi[0] = scale
@@ -157,9 +202,9 @@ def dubiner_recurrence(dim, n, order, ref_pts, Jinv, scale, variant=None):
     for codim in range(dim):
         # Extend the basis from codim to codim + 1
         fa, fb, fc, dfa, dfb, dfc = jacobi_factors(*X[codim:codim+3], *dX[codim:codim+3])
-        ddfc = 2 * outer(dfb, dfb)
+        ddfc = 2 * numpy.outer(dfb, dfb)
         for sub_index in reference_element.lattice_iter(0, n, codim):
-            # handle i = 1
+            # handle i = 0
             icur = idx(*sub_index, 0)
             inext = idx(*sub_index, 1)
 
@@ -178,9 +223,9 @@ def dubiner_recurrence(dim, n, order, ref_pts, Jinv, scale, variant=None):
             if order:
                 dfcur = a * dfa - b * dfb
                 cur = [result[icur] for result in results]
-                for rank in range(1, order+1):
-                    results[rank][inext] = _product_derivative(fcur, dfcur, None,
-                                                               cur, rank)
+                deg = sum(sub_index) + 1
+                for k in range(1, min(order, deg)+1):
+                    results[k][inext] = _product_derivative(fcur, dfcur, None, cur, k)
 
             # general i by recurrence
             for i in range(1, n - sum(sub_index)):
@@ -197,11 +242,10 @@ def dubiner_recurrence(dim, n, order, ref_pts, Jinv, scale, variant=None):
                 ddfprev = -c * ddfc
                 cur = [result[icur] for result in results]
                 prev = [result[iprev] for result in results]
-                for rank in range(1, order+1):
-                    results[rank][inext] = _product_derivative(fcur, dfcur, None,
-                                                               cur, rank)
-                    results[rank][inext] += _product_derivative(fprev, dfprev, ddfprev,
-                                                                prev, rank)
+                deg = sum(sub_index) + 1 + i
+                for k in range(1, min(order, deg)+1):
+                    results[k][inext] = _product_derivative(fcur, dfcur, None, cur, k)
+                    results[k][inext] += _product_derivative(fprev, dfprev, ddfprev, prev, k)
 
         # normalize
         d = codim + 1
@@ -379,13 +423,13 @@ class ExpansionSet(object):
             phi = C0_basis(sd, n, phi)
 
         # Pack linearly independent components into a dictionary
-        result = {(0,) * sd: numpy.asarray(phi[0])}
+        result = {}
+        result[(0,) * sd] = numpy.asarray(phi[0])
         for r in range(1, len(phi)):
-            vr = numpy.transpose(phi[r], tuple(range(1, r+1)) + (0, r+1))
-            for indices in numpy.ndindex(vr.shape[:r]):
-                alpha = tuple(map(indices.count, range(sd)))
-                if alpha not in result:
-                    result[alpha] = vr[indices]
+            vr = numpy.asarray(phi[r])
+            vr = vr.transpose(1, 0, *range(2, vr.ndim))
+            for j, alpha in enumerate(mis(sd, r)):
+                result[alpha] = vr[j]
 
         def distance(alpha, beta):
             return sum(ai != bi for ai, bi in zip(alpha, beta))

--- a/FIAT/expansions.py
+++ b/FIAT/expansions.py
@@ -100,24 +100,24 @@ def _product_derivative(factor: numpy.ndarray,
 
     if dfactor is not None and order >= 1:
         alpha_minus1 = mis(dim, order - 1)
-        idx_of_minus1 = {alpha: i for i, alpha in enumerate(alpha_minus1)}
-        DF = numpy.zeros((len(alphas), *dfactor.shape[1:], len(alpha_minus1)), dtype=dtype)
-        for j, alpha in enumerate(alphas):
+        idx_of_minus1 = {alpha: j for j, alpha in enumerate(alpha_minus1)}
+        DF = numpy.zeros((len(alphas), len(alpha_minus1), *dfactor.shape[1:]), dtype=dtype)
+        for i, alpha in enumerate(alphas):
             for d in range(dim):
                 if alpha[d] < 1:
                     continue
                 alpha_minus = list(alpha)
                 alpha_minus[d] -= 1
-                i = idx_of_minus1[tuple(alpha_minus)]
-                DF[j, ..., i] += alpha[d] * dfactor[d]
+                j = idx_of_minus1[tuple(alpha_minus)]
+                DF[i, j] += alpha[d] * dfactor[d]
         # result += alpha * D F * D^(alpha-1) G
-        result += numpy.einsum('...k,k...->...', DF, operands[order-1])
+        result += numpy.einsum("ij...,j...->i...", DF, operands[order-1])
 
     if ddfactor is not None and order >= 2:
         alpha_minus2 = mis(dim, order - 2)
-        idx_of_minus2 = {alpha: i for i, alpha in enumerate(alpha_minus2)}
-        DDF = numpy.zeros((len(alphas), *ddfactor.shape[2:], len(alpha_minus2)), dtype=dtype)
-        for j, alpha in enumerate(alphas):
+        idx_of_minus2 = {alpha: j for j, alpha in enumerate(alpha_minus2)}
+        DDF = numpy.zeros((len(alphas), len(alpha_minus2), *ddfactor.shape[2:]), dtype=dtype)
+        for i, alpha in enumerate(alphas):
             for d1 in range(dim):
                 for d2 in range(d1, dim):
                     if alpha[d1] < 1 + (d1 == d2) or alpha[d2] < 1 + (d1 == d2):
@@ -125,14 +125,14 @@ def _product_derivative(factor: numpy.ndarray,
                     alpha_minus = list(alpha)
                     alpha_minus[d1] -= 1
                     alpha_minus[d2] -= 1
-                    i = idx_of_minus2[tuple(alpha_minus)]
+                    j = idx_of_minus2[tuple(alpha_minus)]
                     if d1 == d2:
                         a2 = alpha[d1] * (alpha[d1] - 1) // 2
                     else:
                         a2 = alpha[d1] * alpha[d2]
-                    DDF[j, ..., i] += a2 * ddfactor[d1, d2]
+                    DDF[i, j] += a2 * ddfactor[d1, d2]
         # result += alpha*(alpha-1) * D^2 F * D^(alpha-2) G
-        result += numpy.einsum('i...k,k...->i...', DDF, operands[order-2])
+        result += numpy.einsum("ij...,j...->i...", DDF, operands[order-2])
 
     return result
 

--- a/FIAT/macro.py
+++ b/FIAT/macro.py
@@ -484,20 +484,31 @@ class CkPolynomialSet(polynomial_set.PolynomialSet):
         # Impose C^vorder super-smoothness at interior vertices
         # C^forder automatically gives C^{forder+dim-1} at the interior vertex
         verts = numpy.asarray(ref_el.get_vertices())
+        has_vertex_constraints = False
         for vorder in set(order[0].values()):
             vids = [i for i in order[0] if order[0][i] == vorder]
             facets = chain.from_iterable(ref_el.connectivity[(0, sd-1)][v] for v in vids)
             forder = min(order[sd-1][f] for f in facets)
             sorder = forder + sd - 1
             if vorder > sorder:
+                has_vertex_constraints = True
                 jumps = expansion_set.tabulate_jumps(degree, verts[vids], order=vorder)
                 rows.extend(numpy.vstack(jumps[r].T) for r in range(sorder+1, vorder+1))
 
         if len(rows) > 0:
             for row in rows:
                 row *= 1 / max(numpy.max(abs(row)), 1)
-            dual_mat = numpy.vstack(rows)
-            coeffs = polynomial_set.spanning_basis(dual_mat, nullspace=True)
+            if has_vertex_constraints:
+                # Project each constraint block onto the current nullspace so
+                # high-order vertex constraints are not buried in one large SVD.
+                coeffs = numpy.eye(expansion_set.get_num_members(degree))
+                for row in rows:
+                    restricted_row = numpy.dot(row, coeffs.T)
+                    nsp = polynomial_set.spanning_basis(restricted_row, nullspace=True, rtol=1e-12)
+                    coeffs = numpy.dot(nsp, coeffs)
+            else:
+                dual_mat = numpy.vstack(rows)
+                coeffs = polynomial_set.spanning_basis(dual_mat, nullspace=True)
         else:
             coeffs = numpy.eye(expansion_set.get_num_members(degree))
 

--- a/test/FIAT/unit/test_hct.py
+++ b/test/FIAT/unit/test_hct.py
@@ -30,12 +30,6 @@ def make_points(K, degree):
     return pts
 
 
-@pytest.mark.parametrize("degree, space_dimension", [(13, 127), (14, 144)])
-def test_hct_high_order_degree(degree: int, space_dimension: int) -> None:
-    fe = HCT(ufc_simplex(2), degree)
-    assert fe.space_dimension() == space_dimension
-
-
 @pytest.mark.parametrize("reduced", (False, True))
 def test_hct_constant(cell, reduced):
     # Test that bfs associated with point evaluation sum up to 1
@@ -80,3 +74,9 @@ def test_full_polynomials(cell, reduced):
     C1 = CkPolynomialSet(ref_complex, degree, order=1, variant="bubble")
     C1_tab = C1.tabulate(pts)[(0, 0)]
     assert span_greater_equal(tab, C1_tab)
+
+
+@pytest.mark.parametrize("degree, space_dimension", [(13, 127), (14, 144)])
+def test_hct_high_order_degree(degree: int, space_dimension: int) -> None:
+    fe = HCT(ufc_simplex(2), degree)
+    assert fe.space_dimension() == space_dimension

--- a/test/FIAT/unit/test_hct.py
+++ b/test/FIAT/unit/test_hct.py
@@ -30,6 +30,12 @@ def make_points(K, degree):
     return pts
 
 
+@pytest.mark.parametrize("degree, space_dimension", [(13, 127), (14, 144)])
+def test_hct_high_order_degree(degree: int, space_dimension: int) -> None:
+    fe = HCT(ufc_simplex(2), degree)
+    assert fe.space_dimension() == space_dimension
+
+
 @pytest.mark.parametrize("reduced", (False, True))
 def test_hct_constant(cell, reduced):
     # Test that bfs associated with point evaluation sum up to 1

--- a/test/FIAT/unit/test_polynomial.py
+++ b/test/FIAT/unit/test_polynomial.py
@@ -84,6 +84,31 @@ def test_expansion_values(cell, degree):
             assert numpy.allclose(uh, exact, atol=1E-14)
 
 
+@pytest.mark.parametrize("dim", [2, 3])
+@pytest.mark.parametrize("variant", [None, "bubble"])
+def test_high_order_expansion_derivatives(dim, variant):
+    cell = reference_element.default_simplex(dim)
+    degree = 5
+    order = 4
+    points = reference_element.make_lattice(cell.get_vertices(), 5, interior=1)
+
+    fallback = expansions.ExpansionSet(cell, variant=variant)
+    fallback.recurrence_order = 2
+    expected = fallback._tabulate(degree, points, order=order)
+
+    recurrence = expansions.ExpansionSet(cell, variant=variant)
+
+    def get_dmats(*args, **kwargs):
+        raise AssertionError("high-order derivatives should use recurrence tabulation")
+
+    recurrence.get_dmats = get_dmats
+    actual = recurrence._tabulate(degree, points, order=order)
+
+    assert actual.keys() == expected.keys()
+    for alpha in actual:
+        assert numpy.allclose(actual[alpha], expected[alpha], atol=1E-10, rtol=1E-10)
+
+
 @pytest.mark.parametrize("degree", [10])
 def test_expansion_orthonormality(cell, degree):
     U = expansions.ExpansionSet(cell)


### PR DESCRIPTION
Fixes https://github.com/firedrakeproject/firedrake/issues/4152

## Summary
- Tabulate arbitrary-order Dubiner expansion derivatives by applying Leibniz to the recurrence factors.
- Default simplex expansion tabulation to the recurrence path instead of dense differentiation matrices.
- Add order-4 triangle/tetrahedron coverage for orthonormal and bubble variants.

## Tests
- python -m py_compile FIAT/expansions.py test/FIAT/unit/test_polynomial.py
- python -m pytest test/FIAT/unit/test_polynomial.py test/FIAT/unit/test_hierarchical.py::test_hierarchical_sparsity test/FIAT/regression/test_regression.py::test_expansions_jet -q

AI tool used: Codex.