### PR TITLE
Sum-factorisation on simplices

### DIFF
--- a/FIAT/bernstein.py
+++ b/FIAT/bernstein.py
@@ -11,9 +11,134 @@ import numpy
 
 from FIAT.finite_element import FiniteElement
 from FIAT.dual_set import DualSet
-from FIAT.polynomial_set import mis
+from FIAT.expansions import ExpansionSet
+from FIAT.polynomial_set import PolynomialSet, mis
 from FIAT.pointwise_dual import compute_pointwise_dual
-from FIAT.reference_element import make_lattice
+from FIAT.reference_element import make_lattice, multiindex_equal
+
+
+def _bernstein_factors(n, eta):
+    """Tabulate univariate Bernstein factors for a collapsed simplex axis.
+
+    Parameters
+    ----------
+    n : int
+        The total polynomial degree.
+    eta : numpy.ndarray
+        Points on ``[-1, 1]``.
+
+    Returns
+    -------
+    tuple[numpy.ndarray, ...]
+        Value, degree-lowered, and degree-and-index-lowered tables.
+
+    """
+    eta = numpy.asarray(eta)
+    z = 0.5 * (1.0 + eta)
+    shape = (n + 1, n + 1, len(eta))
+    values = numpy.zeros(shape, dtype=z.dtype)
+    lower = numpy.zeros(shape, dtype=z.dtype)
+    shifted = numpy.zeros(shape, dtype=z.dtype)
+    for m in range(n + 1):
+        degree = n - m
+        for i in range(degree + 1):
+            values[m, i] = math.comb(degree, i) * z**i * (1.0 - z)**(degree-i)
+        for i in range(degree):
+            lower[m, i] = math.comb(degree - 1, i) * z**i * (1.0 - z)**(degree-1-i)
+            shifted[m, i+1] = lower[m, i]
+    return values, lower, shifted
+
+
+class BernsteinExpansionSet(ExpansionSet):
+    """Bernstein polynomial expansion set on a simplex."""
+
+    def __init__(self, ref_el):
+        if not ref_el.is_simplex():
+            raise ValueError("Bernstein expansion sets require a simplex")
+        super().__init__(ref_el, scale=1.0)
+
+    def get_duffy_permutation(self, n):
+        """Map Duffy lattice positions to Bernstein expansion members."""
+        dim = self.ref_el.get_spatial_dimension()
+        return numpy.arange(math.comb(n + dim, dim))
+
+    def _tabulate_on_cell(self, n, pts, order=0, cell=0, direction=None):
+        """Tabulate the expansion set and its derivatives on one cell."""
+        if direction is not None:
+            raise NotImplementedError("directional Bernstein tabulation is not implemented")
+
+        ref_el = self.ref_el
+        dim = ref_el.get_spatial_dimension()
+        topology = ref_el.get_topology()
+        vertices = ref_el.get_vertices_of_subcomplex(topology[dim][cell])
+
+        B2R = numpy.vstack([numpy.asarray(vertices).T, numpy.ones(len(vertices))])
+        R2B = numpy.linalg.inv(B2R)
+        points = numpy.asarray(pts)
+        B = numpy.concatenate([points, numpy.ones((*points.shape[:-1], 1))],
+                              axis=-1).dot(R2B.T)
+
+        raw_result = {
+            (derivative, i): vec
+            for i, alpha in enumerate(multiindex_equal(dim+1, n))
+            for o in range(order + 1)
+            for derivative, vec in bernstein_Dx(
+                B, alpha, o, R2B
+            ).items()
+        }
+        num_members = math.comb(n + dim, dim)
+        dtype = numpy.array(list(raw_result.values())).dtype
+        result = {
+            alpha: numpy.zeros((num_members, *points.shape[:-1]), dtype=dtype)
+            for o in range(order + 1)
+            for alpha in mis(dim, o)
+        }
+        for (alpha, i), vec in raw_result.items():
+            result[alpha][i] = vec
+        return result
+
+    def tabulate_duffy(self, n, eta_pts, order=0, cell=0):
+        """Tabulate Bernstein polynomials in separable collapsed form.
+
+        The raw lattice multi-index ``j`` represents the barycentric
+        exponent tuple ``(n - sum(j), *reversed(j))``. Reversing the
+        collapsed axes gives the product from Ainsworth et al.,
+        ``prod_t B[j_t, n - sum(j[:t])]``.
+        """
+        if order > 1:
+            raise NotImplementedError("tabulate_duffy is limited to first derivatives")
+
+        dim = self.ref_el.get_spatial_dimension()
+        assert len(eta_pts) == dim
+        A, _ = self.affine_mappings[cell]
+        axes = tuple(reversed(range(dim)))
+        tables = tuple(_bernstein_factors(n, eta_pts[axis]) for axis in axes)
+        values = tuple(table[0] for table in tables)
+        result = {(0,) * dim: [(1.0, tuple(zip(axes, values)))]}
+
+        if order:
+            lower = tuple(table[1] for table in tables)
+            # On the default (-1, 1) simplex,
+            # d/dxi_l B_alpha^n = n/2 * (B_{alpha-e_{l+1}}^{n-1}
+            #                            - B_{alpha-e_0}^{n-1}).
+            # Both degree-lowered terms retain the separable product form.
+            for k in range(dim):
+                terms = []
+                for ell in range(dim):
+                    coeff = 0.5 * n * A[ell, k]
+                    if coeff == 0.0:
+                        continue
+                    s = dim - 1 - ell
+                    shifted = tuple(table[1] if t < s else
+                                    table[2] if t == s else table[0]
+                                    for t, table in enumerate(tables))
+                    terms.extend(((coeff, tuple(zip(axes, shifted))),
+                                  (-coeff, tuple(zip(axes, lower)))))
+                if not terms:
+                    terms.append((0.0, tuple(zip(axes, values))))
+                alpha = tuple(int(i == k) for i in range(dim))
+                result[alpha] = terms
+        return result
 
 
 class BernsteinDualSet(DualSet):
@@ -33,7 +158,7 @@ class BernsteinDualSet(DualSet):
 
         # Generate triangular barycentric indices
         dim = ref_el.get_spatial_dimension()
-        kss = mis(dim + 1, degree)
+        kss = multiindex_equal(dim+1, degree)
 
         # Fill data structures
         nodes = []
@@ -55,6 +180,13 @@ class Bernstein(FiniteElement):
         dual = BernsteinDualSet(ref_el, degree)
         k = 0  # 0-form
         super().__init__(ref_el, dual, degree, k)
+
+        expansion_set = BernsteinExpansionSet(ref_el)
+        size = math.comb(degree + ref_el.get_spatial_dimension(),
+                         ref_el.get_spatial_dimension())
+        coeffs = numpy.eye(size)
+        self.poly_set = PolynomialSet(ref_el, degree, degree, expansion_set, coeffs)
+
         pts = make_lattice(ref_el.vertices, degree, variant="gll")
         newdual = compute_pointwise_dual(self, pts)
         self.dual = newdual
@@ -62,6 +194,10 @@ class Bernstein(FiniteElement):
     def degree(self):
         """The degree of the polynomial space."""
         return self.get_order()
+
+    def get_nodal_basis(self):
+        """Return the Bernstein basis encoded as a polynomial set."""
+        return self.poly_set
 
     def value_shape(self):
         """The value shape of the finite element functions."""
@@ -90,30 +226,8 @@ class Bernstein(FiniteElement):
         points = numpy.asarray(points)
         cell_points = entity_transform(points)
 
-        # Construct Cartesian to Barycentric coordinate mapping
-        vs = numpy.asarray(ref_el.get_vertices())
-        B2R = numpy.vstack([vs.T, numpy.ones(len(vs))])
-        R2B = numpy.linalg.inv(B2R)
-
-        B = numpy.concatenate([cell_points, numpy.ones((*cell_points.shape[:-1], 1))
-                               ], axis=-1).dot(R2B.T)
-
-        # Evaluate everything
-        deg = self.degree()
-        raw_result = {(alpha, i): vec
-                      for i, ks in enumerate(mis(dim + 1, deg))
-                      for o in range(order + 1)
-                      for alpha, vec in bernstein_Dx(B, ks, o, R2B).items()}
-
-        # Rearrange result
-        space_dim = self.space_dimension()
-        dtype = numpy.array(list(raw_result.values())).dtype
-        result = {alpha: numpy.zeros((space_dim, *points.shape[:-1]), dtype=dtype)
-                  for o in range(order + 1)
-                  for alpha in mis(dim, o)}
-        for (alpha, i), vec in raw_result.items():
-            result[alpha][i] = vec
-        return result
+        return self.poly_set.get_expansion_set()._tabulate(
+            self.degree(), cell_points, order=order)
 
 
 def bernstein_db(points, ks, alpha=None):
@@ -140,9 +254,9 @@ def bernstein_db(points, ks, alpha=None):
 
     ls = ks - alpha
     if any(k < 0 for k in ls):
-        return numpy.zeros(len(points))
+        return numpy.zeros(points.shape[:-1])
     elif all(k == 0 for k in ls):
-        return numpy.ones(len(points))
+        return numpy.ones(points.shape[:-1])
     else:
         # Calculate coefficient
         coeff = math.factorial(ks.sum())

--- a/FIAT/expansions.py
+++ b/FIAT/expansions.py
@@ -24,20 +24,41 @@ def morton_index3(p, q=0, r=0):
 def jrc(a, b, n):
     """Jacobi recurrence coefficients"""
     an = (2*n+1+a+b)*(2*n+2+a+b) / (2*(n+1)*(n+1+a+b))
-    bn = (a+b)*(a-b)*(2*n+1+a+b) / (2*(n+1)*(n+1+a+b)*(2*n+a+b))
-    cn = (n+a)*(n+b)*(2*n+2+a+b) / ((n+1)*(n+1+a+b)*(2*n+a+b))
+    if n == 0:
+        bn = 0.5 * (a - b)
+        cn = 0.0
+    else:
+        bn = (a+b)*(a-b)*(2*n+1+a+b) / (2*(n+1)*(n+1+a+b)*(2*n+a+b))
+        cn = (n+a)*(n+b)*(2*n+2+a+b) / ((n+1)*(n+1+a+b)*(2*n+a+b))
     return an, bn, cn
 
 
 def integrated_jrc(a, b, n):
     """Integrated Jacobi recurrence coefficients"""
-    if n == 1:
+    if n == 0:
+        an = bn = -0.5
+        cn = 0.0
+    elif n == 1:
         an = (a + b + 2) / 2
         bn = (a - 3*b - 2) / 2
         cn = 0.0
     else:
         an, bn, cn = jrc(a-1, b+1, n-1)
     return an, bn, cn
+
+
+def dubiner_jacobi_weights(axis, m, variant):
+    """Return the Jacobi weights for a given Dubiner axis."""
+    if variant == "bubble":
+        alpha = 2 * m
+        beta = 0
+    else:
+        alpha = 2 * m + axis
+        beta = 0
+        if variant == "dual":
+            alpha += 1 + axis
+            beta = 1
+    return alpha, beta
 
 
 def pad_coordinates(ref_pts, embedded_dim):
@@ -49,6 +70,19 @@ def pad_jacobian(A, embedded_dim):
     """Pad coordinate mapping Jacobian by appending zero rows."""
     A = numpy.pad(A, [(0, embedded_dim - A.shape[0]), (0, 0)])
     return tuple(row[..., None] for row in A)
+
+
+def dubiner_norm2(d: int, m: int, i: int, variant: str | None) -> float:
+    """Return the squared normalization for one Dubiner principal function."""
+    if variant is not None:
+        shift = 1 if variant == "dual" else 0
+        p = i + shift
+        alpha = 2 * (m + d * shift) - 1
+        norm2 = (0.5 + d) / d
+        if p > 0 and p + alpha > 0:
+            norm2 *= (p + alpha) * (2*p + alpha) / p
+        return norm2
+    return (2*(m + i) + d) / d
 
 
 def jacobi_factors(x, y, z, dx, dy, dz):
@@ -137,13 +171,7 @@ def _product_derivative(factor: numpy.ndarray,
     return result
 
 
-def dubiner_recurrence(dim: int,
-                       n: int,
-                       order: int,
-                       ref_pts: numpy.ndarray,
-                       Jinv: numpy.ndarray,
-                       scale: float,
-                       variant: str | None = None) -> list[numpy.ndarray]:
+def dubiner_recurrence(dim, n, order, ref_pts, Jinv, scale, variant=None):
     """Tabulate a Dubiner expansion set using the recurrence from (Kirby 2010).
 
     Parameters
@@ -195,29 +223,20 @@ def dubiner_recurrence(dim: int,
     if dim > 3 or dim < 0:
         raise ValueError("Invalid number of spatial dimensions")
 
-    beta = 1 if variant == "dual" else 0
     coefficients = integrated_jrc if variant == "bubble" else jrc
     X = pad_coordinates(ref_pts, pad_dim)
     idx = (lambda p: p, morton_index2, morton_index3)[dim-1]
-    for codim in range(dim):
-        # Extend the basis from codim to codim + 1
-        fa, fb, fc, dfa, dfb, dfc = jacobi_factors(*X[codim:codim+3], *dX[codim:codim+3])
+    for axis in range(dim):
+        # Extend the basis from axis to axis + 1
+        fa, fb, fc, dfa, dfb, dfc = jacobi_factors(*X[axis:axis+3], *dX[axis:axis+3])
         ddfc = 2 * numpy.outer(dfb, dfb)
-        for sub_index in reference_element.lattice_iter(0, n, codim):
+        for sub_index in reference_element.lattice_iter(0, n, axis):
             # handle i = 0
             icur = idx(*sub_index, 0)
             inext = idx(*sub_index, 1)
 
-            if variant == "bubble":
-                alpha = 2 * sum(sub_index)
-                a = b = -0.5
-            else:
-                alpha = 2 * sum(sub_index) + len(sub_index)
-                if variant == "dual":
-                    alpha += 1 + len(sub_index)
-                a = 0.5 * (alpha + beta) + 1.0
-                b = 0.5 * (alpha - beta)
-
+            alpha, beta = dubiner_jacobi_weights(axis, sum(sub_index), variant)
+            a, b, c = coefficients(alpha, beta, 0)
             fcur = a * fa - b * fb
             phi[inext] = phi[icur] * fcur
             if order:
@@ -249,22 +268,85 @@ def dubiner_recurrence(dim: int,
                     results[k][inext] += _product_derivative(fprev, dfprev, ddfprev, prev, k)
 
         # normalize
-        d = codim + 1
-        shift = 1 if variant == "dual" else 0
+        d = axis + 1
         for index in reference_element.lattice_iter(0, n+1, d):
             icur = idx(*index)
-            if variant is not None:
-                p = index[-1] + shift
-                alpha = 2 * (sum(index[:-1]) + d * shift) - 1
-                norm2 = (0.5 + d) / d
-                if p > 0 and p + alpha > 0:
-                    norm2 *= (p + alpha) * (2*p + alpha) / p
-            else:
-                norm2 = (2*sum(index) + d) / d
-            scale = math.sqrt(norm2)
+            scale = math.sqrt(dubiner_norm2(d, sum(index[:-1]), index[-1], variant))
             for result in results:
                 result[icur] *= scale
     return results
+
+
+def principal_functions(n, eta, axis, order=0, variant=None):
+    """Tabulate one axis of the Dubiner basis in collapsed coordinates.
+
+    Returns value (``V``), derivative (``D``), affine derivative (``tD``),
+    and one-power-lowered (``W``) tables indexed by ``(m, i, point)``.
+    """
+    coefficients = integrated_jrc if variant == "bubble" else jrc
+    eta = numpy.asarray(eta)
+    w = 0.5 * (1.0 - eta)
+    npts = eta.shape[0]
+    num_m = 1 if axis == 1 else n + 1
+    modes = ("V",) if order == 0 else ("V", "D", "W", "tD")
+    tables = {mode: numpy.zeros((num_m, n + 1, npts), dtype=eta.dtype)
+              for mode in modes}
+    powers = w[None, :] ** numpy.arange(num_m)[:, None]
+    for m in range(num_m):
+        count = n + 1 - m
+        g = tables["V"][m, :count]
+        dg = numpy.zeros_like(g) if order else None
+        alpha, beta = dubiner_jacobi_weights(axis-1, m, variant)
+        a, b, c = coefficients(alpha, beta, 0)
+        g[0] = 1.0
+        if count > 1:
+            g[1] = a * eta + b
+            if order:
+                dg[1] = a
+            for i in range(1, count - 1):
+                a, b, c = coefficients(alpha, beta, i)
+                factor = a * eta + b
+                g[i + 1] = factor * g[i] - c * g[i - 1]
+                if order:
+                    dg[i + 1] = (factor * dg[i] + a * g[i]
+                                 - c * dg[i - 1])
+
+        if n > 0:
+            normalisation = numpy.fromiter(
+                (math.sqrt(dubiner_norm2(axis, m, i, variant))
+                 for i in range(count)), dtype=float, count=count)
+            g *= normalisation[:, None]
+            if order:
+                dg *= normalisation[:, None]
+
+        if order and m:
+            tables["W"][m, :count] = powers[m - 1] * g
+        if order:
+            tables["D"][m, :count] = (
+                powers[m] * dg - 0.5 * m * tables["W"][m, :count])
+            tables["tD"][m, :count] = (
+                0.5 * (1.0 + eta) * tables["D"][m, :count])
+        g *= powers[m]
+    return tables
+
+
+def _duffy_derivative_factors(tables, direction):
+    """Factorize one physical derivative of the Duffy pullback.
+
+    For the lower-triangular Duffy map, ``d/dxi_direction`` is a sum over
+    collapsed axes up to ``direction``.  Axes before the differentiated one
+    contribute values, axes after it contribute one lower power of their
+    collapse weight, and a non-final differentiated axis also contributes its
+    affine collapsed coordinate.
+    """
+    terms = []
+    for axis in range(direction + 1):
+        derivative = "D" if axis == direction else "tD"
+        factors = tuple(table["V"] for table in tables[:axis])
+        factors += (tables[axis][derivative],)
+        factors += tuple(table["W"] for table in tables[axis + 1:])
+        terms.append(factors)
+    return tuple(terms)
 
 
 def C0_basis(dim, n, tabulations):
@@ -444,6 +526,68 @@ class ExpansionSet(object):
                     for j in range(start, end):
                         vals = numpy.dot(dmat.T, vals)
                 result[alpha] = vals
+        return result
+
+    def get_duffy_permutation(self, n: int) -> numpy.ndarray:
+        """Map lexicographic Duffy lattice positions to expansion members."""
+        dim = self.ref_el.get_spatial_dimension()
+        index = (lambda p: p, morton_index2, morton_index3)[dim - 1]
+        return numpy.fromiter(
+            (index(*alpha[::-1])
+             for alpha in reference_element.lattice_iter(0, n+1, dim)),
+            dtype=int, count=math.comb(n + dim, dim))
+
+    def tabulate_duffy(self, n: int, eta_pts: tuple, order: int = 0, cell: int = 0) -> dict:
+        """Tabulate the expansion set in separable form on collapsed
+        tensor-product points.
+
+        The evaluation points are the image on the reference cell of the
+        tensor-product grid ``eta_pts`` (one ``(-1, 1)`` array per spatial
+        dimension), collapsed onto the default simplex by the Duffy map
+        (`xi_triangle`, `xi_tetrahedron`).
+
+        :returns: a dict mapping each derivative multi-index alpha with
+            ``|alpha| <= order`` to a list of separable terms
+            ``(coeff, factors)``, with ``coeff`` a float and ``factors`` an
+            ordered tuple of ``(axis, table)`` pairs such that::
+
+                D^alpha phi_(i_1..i_d) = sum_terms coeff * prod_q F_q[m_q, i_q, pt_axis_q]
+
+            on the lattice ``i_1 + ... + i_d <= n``, where ``m_1 = 0`` and
+            ``m_t = i_1 + ... + i_{t-1}``. Factor order determines the
+            lattice axes; each axis label selects the corresponding point
+            coordinate. Members are enumerated by the lattice multi-index
+            through `morton_index2` / `morton_index3`. Tables are shared
+            between terms, so consumers may deduplicate them by identity.
+
+            Always the *raw* (continuity=None) tabulation, even when
+            ``self.continuity == "C0"``: `C0_basis`'s recombination mixes
+            lattice multi-indices. Callers needing the C0 basis compose that
+            recombination with their expansion coefficients.
+        """
+        if order > 1:
+            raise NotImplementedError("tabulate_duffy is limited to first derivatives")
+        sd = self.ref_el.get_spatial_dimension()
+        assert len(eta_pts) == sd
+        A, b = self.affine_mappings[cell]
+        scale = self.get_scale(n, cell=cell)
+        if self.variant == "bubble":
+            scale = -scale
+        tables = [principal_functions(n, eta_pts[t], t + 1, order=order, variant=self.variant)
+                  for t in range(sd)]
+
+        result = {(0,) * sd: [
+            (scale, tuple(enumerate(table["V"] for table in tables)))
+        ]}
+        if order > 0:
+            xi_terms = tuple(_duffy_derivative_factors(tables, k)
+                             for k in range(sd))
+            # Push forward to the cell coordinates: d/dx_k = sum_l A[l, k] d/dxi_l.
+            for k in range(sd):
+                alpha = tuple(int(u == k) for u in range(sd))
+                result[alpha] = [(scale * A[l, k], tuple(enumerate(factors)))
+                                 for l in range(sd) if A[l, k] != 0.0
+                                 for factors in xi_terms[l]]
         return result
 
     def _tabulate(self, n, pts, order=0):

--- a/FIAT/expansions.py
+++ b/FIAT/expansions.py
@@ -334,9 +334,9 @@ def _duffy_derivative_factors(tables, direction):
     """Factorize one physical derivative of the Duffy pullback.
 
     For the lower-triangular Duffy map, ``d/dxi_direction`` is a sum over
-    collapsed axes up to ``direction``.  Axes before the differentiated one
-    contribute values, axes after it contribute one lower power of their
-    collapse weight, and a non-final differentiated axis also contributes its
+    collapsed axes up to ``direction``. Axes before the differentiated axis
+    contribute values. Axes after it contribute one lower power of their
+    collapse weight. A non-final differentiated axis also contributes its
     affine collapsed coordinate.
     """
     terms = []
@@ -537,33 +537,44 @@ class ExpansionSet(object):
              for alpha in reference_element.lattice_iter(0, n+1, dim)),
             dtype=int, count=math.comb(n + dim, dim))
 
-    def tabulate_duffy(self, n: int, eta_pts: tuple, order: int = 0, cell: int = 0) -> dict:
-        """Tabulate the expansion set in separable form on collapsed
-        tensor-product points.
+    def tabulate_duffy(self, n: int, eta_pts: tuple, order: int = 0,
+                       cell: int = 0) -> dict:
+        """Tabulate the expansion set in separable Duffy form.
 
-        The evaluation points are the image on the reference cell of the
-        tensor-product grid ``eta_pts`` (one ``(-1, 1)`` array per spatial
-        dimension), collapsed onto the default simplex by the Duffy map
-        (`xi_triangle`, `xi_tetrahedron`).
+        Parameters
+        ----------
+        n : int
+            Polynomial degree.
+        eta_pts : tuple
+            One collapsed-coordinate point array per spatial dimension.
+        order : int, optional
+            Highest derivative order.
+        cell : int, optional
+            Cell in the reference complex.
 
-        :returns: a dict mapping each derivative multi-index alpha with
-            ``|alpha| <= order`` to a list of separable terms
-            ``(coeff, factors)``, with ``coeff`` a float and ``factors`` an
-            ordered tuple of ``(axis, table)`` pairs such that::
+        Returns
+        -------
+        dict
+            Separable terms for each derivative multi-index.
 
-                D^alpha phi_(i_1..i_d) = sum_terms coeff * prod_q F_q[m_q, i_q, pt_axis_q]
+        Notes
+        -----
+        The Duffy map sends the tensor-product grid ``eta_pts`` to the
+        reference cell. Each result term is ``(coefficient, factors)``.
+        ``factors`` is an ordered tuple of ``(axis, table)`` pairs such that::
 
-            on the lattice ``i_1 + ... + i_d <= n``, where ``m_1 = 0`` and
-            ``m_t = i_1 + ... + i_{t-1}``. Factor order determines the
-            lattice axes; each axis label selects the corresponding point
-            coordinate. Members are enumerated by the lattice multi-index
-            through `morton_index2` / `morton_index3`. Tables are shared
-            between terms, so consumers may deduplicate them by identity.
+            D^alpha phi_(i_1..i_d) = sum_terms coeff * prod_q F_q[m_q, i_q, pt_axis_q]
 
-            Always the *raw* (continuity=None) tabulation, even when
-            ``self.continuity == "C0"``: `C0_basis`'s recombination mixes
-            lattice multi-indices. Callers needing the C0 basis compose that
-            recombination with their expansion coefficients.
+        The basis lattice satisfies ``i_1 + ... + i_d <= n``. Its prefix
+        index is ``m_1 = 0`` and ``m_t = i_1 + ... + i_{t-1}``. Factor order
+        determines the lattice axes. Each axis label selects a point
+        coordinate. ``morton_index2`` and ``morton_index3`` enumerate the
+        lattice members. Consumers can deduplicate shared tables by identity.
+
+        The result contains the raw tabulation for every continuity variant.
+        The ``C0_basis`` recombination mixes lattice multi-indices. Callers
+        compose this recombination with their expansion coefficients.
+
         """
         if order > 1:
             raise NotImplementedError("tabulate_duffy is limited to first derivatives")

--- a/finat/duffy.py
+++ b/finat/duffy.py
@@ -5,6 +5,7 @@ import numpy
 import gem
 
 from FIAT.expansions import C0_basis
+from finat.physically_mapped import MappedTabulation
 from finat.point_set import CollapsedTensorProductPointSet
 
 
@@ -23,8 +24,14 @@ class DuffyElement:
                 coordinate_mapping=coordinate_mapping)
         return self.duffy_evaluation(order, ps, entity)
 
-    def get_sparse_coeffs(self):
-        """Return the sparse map from lattice-ordered expansions to dofs."""
+    def get_coefficient_matrix(self) -> gem.Literal:
+        """Return the map from lattice-ordered expansions to dofs.
+
+        Returns
+        -------
+        gem.Literal
+            Coefficient matrix in Duffy lattice order.
+        """
         degree = self.degree
         sd = self.cell.get_spatial_dimension()
         poly_set = self._element.get_nodal_basis()
@@ -39,7 +46,7 @@ class DuffyElement:
         rows, cols = numpy.nonzero(~numpy.isclose(coeffs, 0.0))
         if not len(rows):
             raise ValueError("empty Duffy coefficient matrix")
-        return gem.sparse_matrix(coeffs.shape, rows, cols, coeffs[rows, cols])
+        return gem.Literal(coeffs)
 
     def duffy_evaluation(self, order, ps, entity=None):
         """Return a sum-factorized, dof-indexed tabulation."""
@@ -98,6 +105,8 @@ class DuffyElement:
                 exprs.append(expr)
             result[alpha] = gem.Sum(*exprs)
 
-        coeffs = self.get_sparse_coeffs()
-        return {alpha: coeffs @ gem.FlattenedTensor(expr, multiindex)
-                for alpha, expr in result.items()}
+        coefficients = self.get_coefficient_matrix()
+        tabulation = {
+            alpha: gem.FlattenedTensor(expr, multiindex)
+            for alpha, expr in result.items()}
+        return MappedTabulation(coefficients, tabulation)

--- a/finat/duffy.py
+++ b/finat/duffy.py
@@ -31,6 +31,7 @@ class DuffyElement:
         -------
         gem.Literal
             Coefficient matrix in Duffy lattice order.
+
         """
         degree = self.degree
         sd = self.cell.get_spatial_dimension()

--- a/finat/duffy.py
+++ b/finat/duffy.py
@@ -1,0 +1,103 @@
+from functools import reduce
+
+import numpy
+
+import gem
+
+from FIAT.expansions import C0_basis
+from finat.point_set import CollapsedTensorProductPointSet
+
+
+class DuffyElement:
+    """Mixin for sum-factorized tabulation on collapsed simplex coordinates."""
+
+    def basis_evaluation(self, order, ps, entity=None, coordinate_mapping=None):
+        """Tabulate on a collapsed point set when the element supports it."""
+        sd = self.cell.get_dimension()
+        if not (isinstance(ps, CollapsedTensorProductPointSet)
+                and order <= 1
+                and (entity is None or entity == (sd, 0))
+                and not self.complex.is_macrocell()):
+            return super().basis_evaluation(
+                order, ps, entity=entity,
+                coordinate_mapping=coordinate_mapping)
+        return self.duffy_evaluation(order, ps, entity)
+
+    def get_sparse_coeffs(self):
+        """Return the sparse map from lattice-ordered expansions to dofs."""
+        degree = self.degree
+        sd = self.cell.get_spatial_dimension()
+        poly_set = self._element.get_nodal_basis()
+        coeffs = numpy.array(poly_set.get_coeffs(), copy=True)
+        expansion_set = poly_set.get_expansion_set()
+        if expansion_set.continuity == "C0":
+            recombination, = C0_basis(sd, degree,
+                                      [numpy.eye(coeffs.shape[1])])
+            coeffs = coeffs @ recombination
+
+        coeffs = coeffs[:, expansion_set.get_duffy_permutation(degree)]
+        rows, cols = numpy.nonzero(~numpy.isclose(coeffs, 0.0))
+        if not len(rows):
+            raise ValueError("empty Duffy coefficient matrix")
+        return gem.sparse_matrix(coeffs.shape, rows, cols, coeffs[rows, cols])
+
+    def duffy_evaluation(self, order, ps, entity=None):
+        """Return a sum-factorized, dof-indexed tabulation."""
+        assert isinstance(ps, CollapsedTensorProductPointSet)
+        cell_dim = self.cell.get_dimension()
+        if entity is not None and entity != (cell_dim, 0):
+            raise NotImplementedError(
+                "duffy_evaluation is only supported on the cell interior")
+        if self.complex.is_macrocell():
+            raise NotImplementedError("duffy_evaluation is not supported on split cells")
+
+        degree = self.degree
+        sd = self.cell.get_spatial_dimension()
+        poly_set = self._element.get_nodal_basis()
+        expansion_set = poly_set.get_expansion_set()
+        etas = tuple(2.0 * factor.points.ravel() - 1.0
+                     for factor in ps.factors)
+        duffy = expansion_set.tabulate_duffy(degree, etas, order=order)
+
+        def lookup_index(index_table, multiindex):
+            index_table = gem.Literal(index_table, dtype=gem.uint_type)
+            return gem.VariableIndex(gem.Indexed(index_table, multiindex))
+
+        multiindex = []
+        for _ in range(sd):
+            multiindex.append(gem.JaggedIndex(extent=degree + 1, parents=tuple(multiindex)))
+        multiindex = tuple(multiindex)
+        # The first table axis is the sum of all preceding lattice indices,
+        # not an independent iteration axis, so it is an indirect index.
+        duffy_indices = [0, *multiindex[:1]]
+        for t in range(2, sd):
+            index_table = reduce(numpy.add.outer, (numpy.arange(degree + 1),) * t)
+            index_table = numpy.minimum(index_table, degree)
+            duffy_indices.append(lookup_index(index_table, multiindex[:t]))
+
+        literals = {}
+
+        def as_gem(table):
+            key = id(table)
+            try:
+                return literals[key]
+            except KeyError:
+                return literals.setdefault(key, gem.Literal(table))
+
+        result = {}
+        for alpha, terms in duffy.items():
+            exprs = []
+            for coeff, factors in terms:
+                expr = gem.Product(*(
+                    gem.Indexed(as_gem(table),
+                                (index_expr, i, ps.indices[axis]))
+                    for (axis, table), index_expr, i
+                    in zip(factors, duffy_indices, multiindex)))
+                if coeff != 1.0:
+                    expr = gem.Product(gem.Literal(coeff), expr)
+                exprs.append(expr)
+            result[alpha] = gem.Sum(*exprs)
+
+        coeffs = self.get_sparse_coeffs()
+        return {alpha: coeffs @ gem.FlattenedTensor(expr, multiindex)
+                for alpha, expr in result.items()}

--- a/finat/fiat_elements.py
+++ b/finat/fiat_elements.py
@@ -3,6 +3,7 @@ import gem
 import numpy as np
 from gem.utils import cached_property
 
+from finat.duffy import DuffyElement
 from finat.finiteelementbase import FiniteElementBase
 from finat.point_set import PointSet, PointSingleton
 
@@ -296,9 +297,8 @@ class ScalarFiatElement(FiatElement):
         return ()
 
 
-class Bernstein(ScalarFiatElement):
-    # TODO: Replace this with a smarter implementation
-    def __init__(self, cell, degree):
+class Bernstein(DuffyElement, ScalarFiatElement):
+    def __init__(self, cell: FIAT.reference_element.SimplicialComplex, degree: int) -> None:
         super().__init__(FIAT.Bernstein(cell, degree))
 
 

--- a/finat/point_set.py
+++ b/finat/point_set.py
@@ -1,7 +1,8 @@
 import abc
 import hashlib
-from functools import cached_property
+from functools import cached_property, reduce
 from itertools import chain, product
+from operator import mul
 
 import numpy
 
@@ -231,6 +232,47 @@ class TensorPointSet(AbstractPointSet):
             len(self.factors) == len(other.factors) and \
             all(s.almost_equal(o, tolerance=tolerance)
                 for s, o in zip(self.factors, other.factors))
+
+
+def _collapsed_coordinates(eta):
+    """Map unit tensor-product coordinates to the unit simplex."""
+    return tuple(
+        eta[t] * reduce(
+            mul, (1 - eta[u] for u in range(t + 1, len(eta))), 1)
+        for t in range(len(eta)))
+
+
+class CollapsedTensorProductPointSet(TensorPointSet):
+    r"""A tensor point set mapped to the simplex by collapsed coordinates.
+
+    The factors are one-dimensional point sets on the ``[0, 1]`` reference
+    interval. Their tensor product is mapped by
+
+    .. math:: x_t = \eta_t \prod_{u=t+1}^{d-1}(1 - \eta_u).
+
+    Parameters
+    ----------
+    factors : tuple of AbstractPointSet
+        One-dimensional point sets of collapsed coordinates, one per
+        spatial dimension of the simplex.
+
+    """
+
+    def __init__(self, factors: tuple[AbstractPointSet, ...]) -> None:
+        super().__init__(factors)
+        assert all(ps.dimension == 1 for ps in self.factors)
+
+    @cached_property
+    def points(self):
+        etas = [ps.points.ravel() for ps in self.factors]
+        grids = list(numpy.meshgrid(*etas, indexing="ij"))
+        return numpy.stack([x.ravel() for x in _collapsed_coordinates(grids)],
+                           axis=-1)
+
+    @cached_property
+    def expression(self):
+        etas = [gem.Indexed(ps.expression, (0,)) for ps in self.factors]
+        return gem.ListTensor(_collapsed_coordinates(etas))
 
 
 class FacetPointSet(AbstractPointSet):

--- a/finat/quadrature.py
+++ b/finat/quadrature.py
@@ -1,6 +1,7 @@
 import hashlib
 from abc import ABCMeta, abstractmethod
 from functools import cached_property
+from math import factorial
 
 import gem
 import numpy
@@ -8,8 +9,10 @@ from FIAT.quadrature import GaussLegendreQuadratureLineRule
 from FIAT.quadrature_schemes import create_quadrature as fiat_scheme
 from FIAT.reference_element import LINE, QUADRILATERAL, TENSORPRODUCT
 from gem.utils import safe_repr
+from recursivenodes.quadrature import gaussjacobi
 
-from finat.point_set import (GaussLegendrePointSet, GaussLobattoLegendrePointSet,
+from finat.point_set import (CollapsedTensorProductPointSet,
+                             GaussLegendrePointSet, GaussLobattoLegendrePointSet,
                              KMVPointSet, PointSet, TensorPointSet)
 
 
@@ -26,10 +29,12 @@ def make_quadrature(ref_el, degree, scheme="default"):
     :arg ref_el: The FIAT cell to create the quadrature for.
     :arg degree: The degree of polynomial that the rule should
         integrate exactly.
-    :kwarg scheme: The quadrature scheme, can be choosen from ["default", "canonical", "KMV"]
+    :kwarg scheme: The quadrature scheme, can be choosen from ["default", "canonical", "KMV", "collapsed"]
         "default" -> hard-coded scheme for low degree and collapsed Gauss scheme for high degree,
         "canonical" -> collapsed Gauss scheme,
-        "KMV" -> spectral lumped scheme for low degree (<=6 on triangles, <=3 on tetrahedra).
+        "KMV" -> spectral lumped scheme for low degree (<=6 on triangles, <=3 on tetrahedra),
+        "collapsed" -> collapsed Gauss scheme on simplices, keeping the
+        tensor-product structure in collapsed coordinates for sum factorization.
     """
     if ref_el.get_shape() == TENSORPRODUCT:
         try:
@@ -47,6 +52,9 @@ def make_quadrature(ref_el, degree, scheme="default"):
 
     if degree < 0:
         raise ValueError("Need positive degree, not %d" % degree)
+
+    if scheme.lower() == "collapsed":
+        return collapsed_gauss_jacobi_quadrature(ref_el, degree)
 
     if scheme.lower() in {"kmv", "lump"}:
         fiat_rule = fiat_scheme(ref_el, degree, "KMV")
@@ -67,6 +75,46 @@ def make_quadrature(ref_el, degree, scheme="default"):
         point_set = PointSet(fiat_rule.get_points())
 
     return QuadratureRule(point_set, fiat_rule.get_weights(), ref_el=ref_el, io_ornt_map_tuple=fiat_rule._intrinsic_orientation_permutation_map_tuple)
+
+
+def collapsed_gauss_jacobi_quadrature(ref_el, degree):
+    """Create a collapsed Gauss-Jacobi quadrature rule on a simplex, keeping
+    the tensor-product structure in collapsed coordinates.
+
+    Per-axis Gauss-Jacobi rules are collapsed onto the simplex through the
+    Duffy map ``x_t = eta_t * prod(u > t) (1 - eta_u)``; the Jacobi weight
+    ``(1 - eta_u)**u`` of axis ``u`` absorbs the Duffy Jacobian, so the
+    simplex weights are products of the one-dimensional weights.
+
+    Parameters
+    ----------
+    ref_el : FIAT.reference_element.Cell
+        The simplex to create the quadrature rule on.
+    degree : int
+        The degree of polynomial that the rule should integrate exactly.
+
+    Returns
+    -------
+    CollapsedTensorProductQuadratureRule
+        The structured quadrature rule.
+
+    """
+    if ref_el.is_macrocell():
+        raise NotImplementedError("Collapsed quadrature is not supported on split cells")
+    dim = ref_el.get_spatial_dimension()
+    num_points = (degree + 1 + 1) // 2  # exact integration
+    factors = []
+    for axis in range(dim):
+        xs, ws = gaussjacobi(num_points, axis, 0.0)
+        # Map from the biunit to the unit interval, folding the change of
+        # measure of the Jacobi weight into the quadrature weights
+        xs = (1.0 + xs) / 2.0
+        ws = ws / 2.0 ** (axis + 1)
+        if axis == 0:
+            # The Duffy map produces points on the unit simplex
+            ws = ws * (ref_el.volume() * factorial(dim))
+        factors.append(QuadratureRule(PointSet(xs[:, None]), ws))
+    return CollapsedTensorProductQuadratureRule(factors, ref_el=ref_el)
 
 
 class AbstractQuadratureRule(metaclass=ABCMeta):
@@ -172,6 +220,38 @@ class TensorProductQuadratureRule(AbstractQuadratureRule):
     @cached_property
     def point_set(self):
         return TensorPointSet(q.point_set for q in self.factors)
+
+    @cached_property
+    def weight_expression(self):
+        return gem.Product(*(q.weight_expression for q in self.factors))
+
+
+class CollapsedTensorProductQuadratureRule(AbstractQuadratureRule):
+    """Simplex quadrature rule with tensor-product structure in collapsed
+    coordinates, following Karniadakis & Sherwin.
+
+    Parameters
+    ----------
+    factors : tuple of QuadratureRule
+        One-dimensional quadrature rules of collapsed coordinates on the
+        unit interval, one per spatial dimension of the simplex, with the
+        Duffy Jacobian folded into the weights.
+    ref_el : FIAT.reference_element.Cell
+        The simplex the quadrature rule integrates over.
+
+    """
+
+    def __init__(self, factors, ref_el=None):
+        self.ref_el = ref_el
+        self.factors = tuple(factors)
+        self._intrinsic_orientation_permutation_map_tuple = (None,)
+
+    def __repr__(self):
+        return f"{type(self).__name__}({self.factors!r}, {self.ref_el!r})"
+
+    @cached_property
+    def point_set(self):
+        return CollapsedTensorProductPointSet([q.point_set for q in self.factors])
 
     @cached_property
     def weight_expression(self):

--- a/finat/quadrature.py
+++ b/finat/quadrature.py
@@ -17,24 +17,30 @@ from finat.point_set import (CollapsedTensorProductPointSet,
 
 
 def make_quadrature(ref_el, degree, scheme="default"):
-    """
-    Generate quadrature rule for given reference element
-    that will integrate an polynomial of order 'degree' exactly.
+    """Create a quadrature rule for a reference element.
 
-    For low-degree polynomials on triangles (<=50) and tetrahedra (<=15), this
-    uses hard-coded rules, otherwise it falls back to a collapsed
-    Gauss scheme on simplices.  On tensor-product cells, it is a
-    tensor-product quadrature rule of the subcells.
+    Parameters
+    ----------
+    ref_el : FIAT.reference_element.Cell
+        Reference cell.
+    degree : int or tuple of int
+        Exact polynomial degree.
+    scheme : str, optional
+        Quadrature scheme.
 
-    :arg ref_el: The FIAT cell to create the quadrature for.
-    :arg degree: The degree of polynomial that the rule should
-        integrate exactly.
-    :kwarg scheme: The quadrature scheme, can be choosen from ["default", "canonical", "KMV", "collapsed"]
-        "default" -> hard-coded scheme for low degree and collapsed Gauss scheme for high degree,
-        "canonical" -> collapsed Gauss scheme,
-        "KMV" -> spectral lumped scheme for low degree (<=6 on triangles, <=3 on tetrahedra),
-        "collapsed" -> collapsed Gauss scheme on simplices, keeping the
-        tensor-product structure in collapsed coordinates for sum factorization.
+    Returns
+    -------
+    QuadratureRule
+        Quadrature points, weights, and reference cell.
+
+    Notes
+    -----
+    The ``default`` scheme uses tabulated simplex rules at low degree. It
+    uses collapsed Gauss rules at high degree. The ``canonical`` scheme uses
+    collapsed Gauss rules with flat points. The ``KMV`` scheme uses spectral
+    lumped rules. The ``collapsed`` scheme retains the tensor-product Duffy
+    structure for sum factorization.
+
     """
     if ref_el.get_shape() == TENSORPRODUCT:
         try:
@@ -78,13 +84,7 @@ def make_quadrature(ref_el, degree, scheme="default"):
 
 
 def collapsed_gauss_jacobi_quadrature(ref_el, degree):
-    """Create a collapsed Gauss-Jacobi quadrature rule on a simplex, keeping
-    the tensor-product structure in collapsed coordinates.
-
-    Per-axis Gauss-Jacobi rules are collapsed onto the simplex through the
-    Duffy map ``x_t = eta_t * prod(u > t) (1 - eta_u)``; the Jacobi weight
-    ``(1 - eta_u)**u`` of axis ``u`` absorbs the Duffy Jacobian, so the
-    simplex weights are products of the one-dimensional weights.
+    """Create a structured collapsed Gauss-Jacobi quadrature rule.
 
     Parameters
     ----------
@@ -97,6 +97,13 @@ def collapsed_gauss_jacobi_quadrature(ref_el, degree):
     -------
     CollapsedTensorProductQuadratureRule
         The structured quadrature rule.
+
+    Notes
+    -----
+    The Duffy map is
+    ``x_t = eta_t * prod(u > t) (1 - eta_u)``. The Jacobi weight
+    ``(1 - eta_u)**u`` absorbs the Duffy Jacobian on axis ``u``. The simplex
+    weights are products of the one-dimensional weights.
 
     """
     if ref_el.is_macrocell():

--- a/finat/spectral.py
+++ b/finat/spectral.py
@@ -4,8 +4,10 @@ import gem
 from abc import ABCMeta, abstractmethod
 
 from finat.citations import cite
+from finat.duffy import DuffyElement
 from finat.fiat_elements import ScalarFiatElement, Lagrange, DiscontinuousLagrange
-from finat.point_set import GaussLobattoLegendrePointSet, GaussLegendrePointSet, KMVPointSet
+from finat.point_set import (GaussLobattoLegendrePointSet, GaussLegendrePointSet,
+                             KMVPointSet)
 
 
 class SpectralElement(metaclass=ABCMeta):
@@ -64,7 +66,7 @@ class KongMulderVeldhuizen(SpectralElement, ScalarFiatElement):
         cite("Geevers2018new")
 
 
-class Legendre(ScalarFiatElement):
+class Legendre(DuffyElement, ScalarFiatElement):
     """DG element with Legendre polynomials."""
 
     def __init__(self, cell, degree, variant=None):
@@ -72,7 +74,7 @@ class Legendre(ScalarFiatElement):
         super().__init__(fiat_element)
 
 
-class IntegratedLegendre(ScalarFiatElement):
+class IntegratedLegendre(DuffyElement, ScalarFiatElement):
     """CG element with integrated Legendre polynomials."""
 
     def __init__(self, cell, degree, variant=None):

--- a/gem/gem.py
+++ b/gem/gem.py
@@ -34,7 +34,7 @@ __all__ = ['Node', 'Identity', 'Literal', 'Zero', 'Failure',
            'MathFunction', 'MinValue', 'MaxValue', 'Comparison',
            'LogicalNot', 'LogicalAnd', 'LogicalOr', 'Conditional',
            'Index', 'JaggedIndex', 'RaggedIndex', 'VariableIndex', 'Indexed', 'ComponentTensor',
-           'IndexSum', 'ListTensor', 'Concatenate', 'Delta',
+           'FlattenedTensor', 'IndexSum', 'ListTensor', 'Concatenate', 'Delta',
            'OrientationVariableIndex',
            'index_sum', 'partial_indexed', 'reshape', 'view',
            'indices', 'as_gem', 'FlexiblyIndexed',
@@ -1010,6 +1010,36 @@ class ComponentTensor(Node):
         return self
 
 
+class FlattenedTensor(Node):
+    """Lexicographically flattened view of a jagged tensor.
+
+    Parameters
+    ----------
+    expression : Node
+        Scalar expression indexed by ``multiindex``.
+    multiindex : tuple of Index
+        Rectangular or jagged tensor axes, in flattening order.
+
+    """
+
+    __slots__ = ('children', 'multiindex', 'shape')
+    __back__ = ('multiindex',)
+
+    def __init__(self, expression: Node,
+                 multiindex: tuple[Index, ...]) -> None:
+        assert not expression.shape
+        multiindex = tuple(multiindex)
+        assert set(multiindex) <= set(expression.free_indices)
+        self.children = (expression,)
+        self.multiindex = multiindex
+        self.shape = (len(_jagged_lattice(multiindex)),)
+        self.free_indices = unique(set(expression.free_indices) - set(multiindex))
+
+    def lattice_points(self) -> numpy.ndarray:
+        """Return the in-bounds lattice multi-indices in flat order."""
+        return _jagged_lattice(self.multiindex)
+
+
 def _jagged_layout(multiindex: tuple[Index, ...]) -> tuple:
     """Return a structural description of a jagged iteration domain."""
     positions = {}
@@ -1312,6 +1342,28 @@ class Concatenate(Node):
         return (int(sum(numpy.prod(child.shape, dtype=int) for child in self.children)),)
 
 
+@lru_cache(maxsize=128)
+def _permutation_source(index):
+    """Return the source index and table for a tabulated permutation."""
+    if not isinstance(index, VariableIndex):
+        return None
+    expression = index.expression
+    if not isinstance(expression, Indexed) or len(expression.multiindex) != 1:
+        return None
+    source, = expression.multiindex
+    table, = expression.children
+    if (not isinstance(source, Index) or source.extent is None
+            or not isinstance(table, Literal)):
+        return None
+    entries = table.array
+    if (entries.shape != (source.extent,)
+            or not numpy.all(entries < source.extent)
+            or not numpy.all(numpy.bincount(
+                entries, minlength=source.extent) == 1)):
+        return None
+    return source, table
+
+
 class Delta(Scalar, Terminal):
     __slots__ = ('i', 'j')
     __front__ = ('i', 'j')
@@ -1327,6 +1379,13 @@ class Delta(Scalar, Terminal):
         # \delta_{i,i} = 1
         if i == j:
             return one
+
+        # A shared bijection preserves equality: delta(p(i), p(j)) = delta(i, j).
+        source_i = _permutation_source(i)
+        source_j = _permutation_source(j)
+        if (source_i is not None and source_j is not None
+                and source_i[1] == source_j[1]):
+            return Delta(source_i[0], source_j[0], dtype=dtype)
 
         # Fixed indices
         if isinstance(i, Integral) and isinstance(j, Integral):

--- a/gem/impero_utils.py
+++ b/gem/impero_utils.py
@@ -30,6 +30,7 @@ class NoopError(Exception):
 
 def preprocess_gem(expressions, replace_delta=True, remove_componenttensors=True):
     """Lower GEM nodes that cannot be translated to C directly."""
+    expressions = optimise.replace_flattened(expressions)
     if remove_componenttensors:
         expressions = optimise.remove_componenttensors(expressions)
     if replace_delta:

--- a/gem/interpreter.py
+++ b/gem/interpreter.py
@@ -8,7 +8,7 @@ from functools import singledispatch
 import itertools
 
 from gem import gem, node
-from gem.optimise import replace_delta
+from gem.optimise import replace_delta, replace_flattened
 
 __all__ = ("evaluate", )
 
@@ -401,6 +401,7 @@ def evaluate(expressions, bindings=None):
         exprs = tuple(expressions)
     except TypeError:
         exprs = (expressions, )
+    exprs = replace_flattened(exprs)
     mapper = node.Memoizer(_evaluate)
     mapper.bindings = bindings if bindings is not None else {}
     return list(map(mapper, exprs))

--- a/gem/optimise.py
+++ b/gem/optimise.py
@@ -18,7 +18,8 @@ from gem.gem import (Node, Failure, Identity, Constant, Literal, Zero,
                      Power, MathFunction, MinValue, MaxValue, Inverse, Solve,
                      Index, VariableIndex, Indexed, FlexiblyIndexed,
                      IndexSum, JaggedIndex, RaggedIndex, ComponentTensor, ListTensor,
-                     Delta, _jagged_lattice, partial_indexed, one)
+                     FlattenedTensor, Delta, _jagged_lattice,
+                     partial_indexed, uint_type, one)
 
 
 @singledispatch
@@ -1349,6 +1350,9 @@ def contraction(expression, ignore=None):
     evaluation in mind.
     """
 
+    distribute = any(isinstance(node, FlattenedTensor)
+                     for node in traversal((expression,)))
+
     # Common memoizer to remove ComponentTensors
     index_replacer = MemoizerArg(filtered_replace_indices)
 
@@ -1362,15 +1366,21 @@ def contraction(expression, ignore=None):
         sum_indices, factors = delta_elimination(sum_indices, factors, index_replacer=index_replacer)
         factors = [index_replacer(f, ()) for f in factors]
 
+        expression = IndexSum(Product(*factors), sum_indices)
+        expression = unflatten(expression)
+        sum_indices, factors = traverse_product(expression, index_replacer=index_replacer)
+        sum_indices, factors = delta_elimination(sum_indices, factors, index_replacer=index_replacer)
+        factors = [index_replacer(f, ()) for f in factors]
         if ignore is not None:
             # TODO: This is a really blunt instrument and one might
             # plausibly want the ignored indices to be contracted on
             # the inside rather than the outside.
             extra = tuple(i for i in sum_indices if i in ignore)
             to_factor = tuple(i for i in sum_indices if i not in ignore)
-            return IndexSum(sum_factorise(to_factor, factors), extra)
+            return IndexSum(sum_factorise(to_factor, factors,
+                                          distribute=distribute), extra)
         else:
-            return sum_factorise(sum_indices, factors)
+            return sum_factorise(sum_indices, factors, distribute=distribute)
 
     # Sometimes the value shape is composed as a ListTensor, which
     # could get in the way of decomposing factors.  In particular,
@@ -1495,3 +1505,378 @@ def aggressive_unroll(expression):
         (expression,), predicate=lambda index: not isinstance(index, RaggedIndex))
     expression, = remove_componenttensors((expression,))
     return expression
+
+
+def _clone_multiindex(multiindex: Iterable[Index]) -> tuple[Index, ...]:
+    """Clone an index tuple while preserving its internal jagged parents."""
+    clones = {}
+    for index in multiindex:
+        if isinstance(index, JaggedIndex):
+            parents = tuple(clones[parent] for parent in index.parents)
+            clones[index] = JaggedIndex(extent=index.extent, parents=parents)
+        else:
+            clones[index] = Index(extent=index.extent)
+    return tuple(clones[index] for index in multiindex)
+
+
+def _replace_gathers(node: Node, self, subst: tuple) -> Node:
+    """Replace selected flat gathers, then apply ordinary index substitution."""
+    try:
+        return self.replacements[node]
+    except KeyError:
+        return filtered_replace_indices(node, self, subst)
+
+
+def _flattened_layout(gather: Indexed) -> tuple:
+    """Return a structural key for a flattened tensor's iteration lattice."""
+    tensor, = gather.children
+    positions = {index: position
+                 for position, index in enumerate(tensor.multiindex)}
+    return tuple((type(index), index.extent,
+                  tuple(positions[parent]
+                        for parent in getattr(index, "parents", ())))
+                 for index in tensor.multiindex)
+
+
+def _find_unflattenable_index(
+        nodes: Iterable[Node],
+        indices: Iterable[Index]) -> tuple | None:
+    """Find compatible flat gathers at one unconstrained index.
+
+    An index occurring in a :class:`Delta` is not a candidate.  Cancelling
+    that delta is cheaper than replacing the flat index with a full lattice
+    loop and an indirect comparison.
+    """
+    indices = tuple(indices)
+    index_set = frozenset(indices)
+    constrained = set()
+    gathers = defaultdict(OrderedDict)
+    for node in nodes:
+        if isinstance(node, Delta):
+            constrained.update(node.free_indices)
+        elif (isinstance(node, Indexed)
+              and len(node.multiindex) == 1
+              and node.multiindex[0] in index_set
+              and isinstance(node.children[0], FlattenedTensor)):
+            gathers[node.multiindex[0]].setdefault(node)
+
+    for index in indices:
+        candidates = tuple(gathers[index])
+        layouts = {_flattened_layout(gather) for gather in candidates}
+        if candidates and len(layouts) == 1 and index not in constrained:
+            layout, = layouts
+            return index, layout, candidates
+    return None
+
+
+def _prepare_unflattening(
+        gathers: tuple[Indexed, ...]) -> tuple[MemoizerArg, tuple, VariableIndex]:
+    """Prepare one joint rewrite of compatible flat gathers.
+
+    Each flattened tensor is inlined on the same fresh lattice multiindex.
+    ``flat_index`` maps that lattice point back to the original flat ordering
+    wherever the old index is still needed, notably in the return variable.
+    """
+    gather = gathers[0]
+    tensor, = gather.children
+    assert all(_flattened_layout(other) == _flattened_layout(gather)
+               for other in gathers)
+    multiindex = _clone_multiindex(tensor.multiindex)
+    replacer = MemoizerArg(filtered_replace_indices)
+    mapper = MemoizerArg(_replace_gathers)
+    mapper.replacements = {}
+    for other in gathers:
+        tensor, = other.children
+        mapper.replacements[other] = replacer(
+            tensor.children[0], tuple(zip(tensor.multiindex, multiindex)))
+
+    shape = tuple(index.extent for index in multiindex)
+    points = gather.children[0].lattice_points()
+    ordering = numpy.zeros(shape, dtype=uint_type)
+    ordering[tuple(points.T)] = numpy.arange(len(points))
+    flat_index = VariableIndex(Indexed(
+        Literal(ordering, dtype=uint_type), multiindex))
+    return mapper, multiindex, flat_index
+
+
+def _separable_sum(node: Node, indices: frozenset[Index]) -> bool:
+    """Whether distributing a sum exposes smaller index dependencies."""
+    if not isinstance(node, Sum):
+        return False
+    involved = indices.intersection(node.free_indices)
+    return bool(involved) and any(
+        any(indices.intersection(factor.free_indices) < involved
+            for factor in traverse_product(summand)[1])
+        for summand in traverse_sum(node))
+
+
+def _unflatten_contracted_terms(
+        summand: Node, index: Index) -> tuple[list, list[Node]]:
+    """Unflatten additive terms containing a gather at a contracted index."""
+    rewritten = []
+    leftover = []
+    for term in traverse_sum(summand):
+        candidate = _find_unflattenable_index(
+            traversal((term,)), (index,))
+        if candidate is None:
+            leftover.append(term)
+            continue
+        _, _, gathers = candidate
+        mapper, multiindex, flat_index = _prepare_unflattening(gathers)
+        term = mapper(term, ((index, flat_index),))
+        own = frozenset(multiindex)
+        predicate = partial(_separable_sum, indices=own)
+        rewritten.extend(
+            (multiindex, piece)
+            for piece in _distribute_sum(term, predicate=predicate))
+    return rewritten, leftover
+
+
+def _unflatten_contractions(node: Node, self) -> Node:
+    """Memoizer callback for flat indices bound by an :class:`IndexSum`."""
+    node = reuse_if_untouched(node, self)
+    if not isinstance(node, IndexSum):
+        return node
+    summand, = node.children
+    for index in node.multiindex:
+        rewritten, leftover = _unflatten_contracted_terms(summand, index)
+        if not rewritten:
+            continue
+        rest = tuple(other for other in node.multiindex if other != index)
+        pieces = []
+        for own, term in rewritten:
+            term = self(IndexSum(
+                term, own + tuple(i for i in rest if i in term.free_indices)))
+            indices, factors = traverse_product(term)
+            indices, factors = delta_elimination(indices, factors)
+            pieces.append(sum_factorise(indices, factors))
+        if leftover:
+            residual = make_sum(leftover)
+            indices = tuple(i for i in (index,) + rest
+                            if i in residual.free_indices)
+            pieces.append(self(IndexSum(residual, indices)))
+        return make_sum(pieces)
+    return node
+
+
+def unflatten(expression: Node) -> Node:
+    """Replace flat contractions by loops over their jagged lattices.
+
+    A contraction over the flat axis of a :class:`FlattenedTensor` hides its
+    tensor-product factors.  This rewrite substitutes the tensor's own
+    (possibly jagged) multiindex for that flat axis, enabling the ordinary
+    contraction optimizer to recover sum factorisation.
+    """
+    if not any(isinstance(node, FlattenedTensor)
+               for node in traversal((expression,))):
+        return expression
+    return Memoizer(_unflatten_contractions)(expression)
+
+
+def _has_flat_gather(nodes: Iterable[Node],
+                     indices: Iterable[Index]) -> bool:
+    """Whether ``nodes`` gather a flattened tensor at one of ``indices``."""
+    indices = frozenset(indices)
+    return any(isinstance(node, Indexed)
+               and len(node.multiindex) == 1
+               and node.multiindex[0] in indices
+               and isinstance(node.children[0], FlattenedTensor)
+               for node in nodes)
+
+
+def _unflatten_free_indices(
+        variable: Node, expression: Node, *,
+        split_separable_sums: bool) -> tuple[list[tuple[Node, Node]], bool]:
+    """Replace flattened gathers at free indices of one assignment.
+
+    Compatible gathers are rewritten together.  Distribution is restricted
+    to deltas until a lattice has been exposed; the optional legacy path then
+    splits separable sums immediately.
+    """
+    pending = [(variable, expression)]
+    outputs = []
+    changed = False
+    while pending:
+        current_variable, current_expression = pending.pop()
+        nodes = tuple(traversal((current_expression,)))
+        candidate = _find_unflattenable_index(
+            nodes, current_variable.free_indices)
+        if candidate is not None:
+            index, layout, gathers = candidate
+            groups = OrderedDict([
+                ((index, layout), ([current_expression], list(gathers)))])
+        elif not _has_flat_gather(nodes, current_variable.free_indices):
+            outputs.append((current_variable, current_expression))
+            continue
+        else:
+            predicate = (lambda node: isinstance(node, Delta)) \
+                if any(isinstance(node, Delta) for node in nodes) else None
+            groups = OrderedDict()
+            for term in _distribute_sum(
+                    current_expression, predicate=predicate):
+                candidate = _find_unflattenable_index(
+                    traversal((term,)), current_variable.free_indices)
+                key = candidate[:2] if candidate is not None else None
+                terms, gathers = groups.setdefault(key, ([], []))
+                terms.append(term)
+                if candidate is not None:
+                    gathers.extend(candidate[2])
+
+        for key, (terms, gathers) in groups.items():
+            term = make_sum(terms)
+            if key is None:
+                outputs.append((current_variable, term))
+                continue
+
+            changed = True
+            index, _ = key
+            gathers = tuple(OrderedDict.fromkeys(gathers))
+            mapper, multiindex, flat_index = _prepare_unflattening(gathers)
+            substitution = ((index, flat_index),)
+            new_variable = MemoizerArg(filtered_replace_indices)(
+                current_variable, substitution)
+            new_expression = mapper(term, substitution)
+            if split_separable_sums:
+                lattice_indices = frozenset(multiindex)
+                predicate = partial(_separable_sum, indices=lattice_indices)
+                pending.extend(
+                    (new_variable, piece)
+                    for piece in _distribute_sum(
+                        new_expression, predicate=predicate))
+            else:
+                pending.append((new_variable, new_expression))
+    return outputs, changed
+
+
+def _refactor_unflattened_outputs(
+        outputs: list[tuple[Node, Node]]) -> list[tuple[Node, Node]] | None:
+    r"""Recover sum factorisation after exposing every argument lattice.
+
+    Consider a bilinear form whose argument tabulations are transformed by
+    sparse matrices,
+
+    .. math::
+
+        A_{ij} = \sum_q (S B(q))_i\,G(q)\,(T C(q))_j.
+
+    Sparse-delta cancellation moves rows of ``S`` and ``T`` into the return
+    scatter.  Both flat argument indices must then be replaced by their
+    jagged lattice multiindices *before* expanding derivative sums.  Expanding
+    after only one replacement duplicates the second lattice once per
+    summand, producing many equivalent loop nests.
+
+    The refactorisation is valid when the non-tabulation part of every
+    monomial is independent of the argument indices.  This condition says
+    exactly that the sparse transforms have been absorbed by the scatter.
+    Dense or otherwise residual transforms use the conservative legacy path.
+    """
+    # Local imports avoid a module cycle: refactorise and coffee both use
+    # primitive transformations defined in this module.
+    from gem.coffee import optimise_monomial_sum
+    from gem.refactorise import (
+        ATOMIC, COMPOUND, OTHER, FactorisationError, collect_monomials,
+    )
+
+    candidates = []
+    has_nontrivial_sum = False
+    for variable, expression in outputs:
+        argument_indices = frozenset(variable.free_indices)
+        contraction_indices = frozenset(
+            index
+            for node in traversal((expression,))
+            if isinstance(node, IndexSum)
+            for index in node.multiindex)
+
+        def classify(node):
+            involved = argument_indices.intersection(node.free_indices)
+            if not involved:
+                return OTHER
+            if isinstance(node, Indexed):
+                return ATOMIC if contraction_indices.intersection(
+                    node.free_indices) else OTHER
+            return COMPOUND
+
+        try:
+            monomial_sum, = collect_monomials([expression], classify)
+        except FactorisationError:
+            return None
+
+        monomials = tuple(monomial_sum)
+        if any(argument_indices.intersection(monomial.rest.free_indices)
+               for monomial in monomials):
+            return None
+        has_nontrivial_sum |= len(monomials) > 1
+        sum_indices = tuple(OrderedDict.fromkeys(
+            index
+            for monomial in monomials
+            for index in monomial.sum_indices))
+        candidates.append(
+            (variable, monomial_sum, sum_indices))
+
+    if not has_nontrivial_sum:
+        return None
+    return [
+        (variable, optimise_monomial_sum(
+            monomial_sum, variable.index_ordering(), sum_indices))
+        for variable, monomial_sum, sum_indices in candidates
+    ]
+
+
+def unflatten_returns(
+        pairs: Iterable[tuple[Node, Node]]) -> list[tuple[Node, Node]]:
+    """Unflatten free argument indices in assignment pairs.
+
+    Every compatible argument lattice is exposed jointly.  Bilinear
+    expressions are then refactorised as monomial sums so that sparse
+    argument transforms remain in the output scatter while quadrature
+    contractions recover their one-dimensional factors.  Expressions with
+    residual argument-dependent transforms retain the established local
+    distribution strategy.
+    """
+    pairs = list(pairs)
+    if not any(isinstance(node, FlattenedTensor)
+               for _, expression in pairs
+               for node in traversal((expression,))):
+        return pairs
+
+    result = []
+    for variable, expression in pairs:
+        expression = eliminate_deltas(expression)
+        joint_outputs, changed = _unflatten_free_indices(
+            variable, expression, split_separable_sums=False)
+        refactored = _refactor_unflattened_outputs(
+            joint_outputs) if changed else None
+        if refactored is not None:
+            result.extend(refactored)
+            continue
+
+        outputs, changed = _unflatten_free_indices(
+            variable, expression, split_separable_sums=True)
+        if changed or any(isinstance(node, Delta)
+                          for _, output in outputs
+                          for node in traversal((output,))):
+            outputs = [(output_variable, contraction(output))
+                       for output_variable, output in outputs]
+        result.extend(outputs)
+    return result
+
+
+def _replace_flattened(node, self):
+    node = reuse_if_untouched(node, self)
+    if not isinstance(node, FlattenedTensor):
+        return node
+    expression, = node.children
+    points = node.lattice_points()
+    index = Index(extent=node.shape[0])
+    subst = tuple(
+        (axis, VariableIndex(Indexed(
+            Literal(points[:, position], dtype=uint_type), (index,))))
+        for position, axis in enumerate(node.multiindex))
+    body = MemoizerArg(filtered_replace_indices)(expression, subst)
+    return ComponentTensor(body, (index,))
+
+
+def replace_flattened(expressions):
+    """Lower remaining flattened tensors to indirect flat-index gathers."""
+    mapper = Memoizer(_replace_flattened)
+    return [mapper(expression) for expression in expressions]

--- a/gem/optimise.py
+++ b/gem/optimise.py
@@ -1649,16 +1649,13 @@ def _prepare_unflattening(
     points = gather.children[0].lattice_points()
     ordering = numpy.zeros(shape, dtype=uint_type)
     ordering[tuple(points.T)] = numpy.arange(len(points))
-    flat_index = VariableIndex(Indexed(
-        Literal(ordering, dtype=uint_type), multiindex))
-    if permutation is None:
-        source_index = flat_index
-    else:
+    if permutation is not None:
         inverse = numpy.empty(len(permutation), dtype=uint_type)
         inverse[numpy.asarray(permutation)] = numpy.arange(
             len(permutation), dtype=uint_type)
-        source_index = VariableIndex(Indexed(
-            Literal(inverse, dtype=uint_type), (flat_index,)))
+        ordering = inverse[ordering]
+    source_index = VariableIndex(Indexed(
+        Literal(ordering, dtype=uint_type), multiindex))
     return mapper, multiindex, source_index
 
 

--- a/gem/optimise.py
+++ b/gem/optimise.py
@@ -1538,6 +1538,46 @@ def _flattened_layout(gather: Indexed) -> tuple:
                  for index in tensor.multiindex)
 
 
+def _flat_index_bijection(
+        index, extent: int) -> tuple[Index, tuple[int, ...] | None] | None:
+    """Identify a direct or compile-time bijective flat index.
+
+    Parameters
+    ----------
+    index
+        Index of a flattened tensor.
+    extent
+        Length of the flattened tensor.
+
+    Returns
+    -------
+    tuple or None
+        Source index and its forward permutation. A direct index has no
+        permutation.
+
+    """
+    if isinstance(index, Index):
+        return (index, None) if index.extent == extent else None
+    if not isinstance(index, VariableIndex):
+        return None
+
+    expression = index.expression
+    if not (isinstance(expression, Indexed)
+            and len(expression.multiindex) == 1
+            and isinstance(expression.multiindex[0], Index)
+            and isinstance(expression.children[0], Literal)):
+        return None
+    source, = expression.multiindex
+    table, = expression.children
+    if table.shape != (source.extent,) or source.extent != extent:
+        return None
+
+    permutation = tuple(map(int, table.array))
+    if tuple(sorted(permutation)) != tuple(range(extent)):
+        return None
+    return source, permutation
+
+
 def _find_unflattenable_index(
         nodes: Iterable[Node],
         indices: Iterable[Index]) -> tuple | None:
@@ -1550,37 +1590,52 @@ def _find_unflattenable_index(
     indices = tuple(indices)
     index_set = frozenset(indices)
     constrained = set()
-    gathers = defaultdict(OrderedDict)
+    gathers = defaultdict(lambda: defaultdict(OrderedDict))
     for node in nodes:
         if isinstance(node, Delta):
             constrained.update(node.free_indices)
         elif (isinstance(node, Indexed)
               and len(node.multiindex) == 1
-              and node.multiindex[0] in index_set
               and isinstance(node.children[0], FlattenedTensor)):
-            gathers[node.multiindex[0]].setdefault(node)
+            tensor, = node.children
+            bijection = _flat_index_bijection(
+                node.multiindex[0], tensor.shape[0])
+            if bijection is None:
+                continue
+            source, permutation = bijection
+            if source in index_set:
+                key = _flattened_layout(node), permutation
+                gathers[source][key].setdefault(node)
 
     for index in indices:
-        candidates = tuple(gathers[index])
-        layouts = {_flattened_layout(gather) for gather in candidates}
-        if candidates and len(layouts) == 1 and index not in constrained:
-            layout, = layouts
-            return index, layout, candidates
+        groups = gathers[index]
+        if len(groups) == 1 and index not in constrained:
+            layout, candidates = next(iter(groups.items()))
+            return index, layout, tuple(candidates)
     return None
 
 
 def _prepare_unflattening(
-        gathers: tuple[Indexed, ...]) -> tuple[MemoizerArg, tuple, VariableIndex]:
+        gathers: tuple[Indexed, ...],
+        source: Index) -> tuple[MemoizerArg, tuple, VariableIndex]:
     """Prepare one joint rewrite of compatible flat gathers.
 
     Each flattened tensor is inlined on the same fresh lattice multiindex.
-    ``flat_index`` maps that lattice point back to the original flat ordering
-    wherever the old index is still needed, notably in the return variable.
+    The returned index maps each lattice point to the original source index.
+    A compile-time permutation is inverted before the index is used in the
+    return variable.
     """
     gather = gathers[0]
     tensor, = gather.children
     assert all(_flattened_layout(other) == _flattened_layout(gather)
                for other in gathers)
+    bijection = _flat_index_bijection(
+        gather.multiindex[0], tensor.shape[0])
+    assert bijection is not None and bijection[0] == source
+    permutation = bijection[1]
+    assert all(_flat_index_bijection(
+        other.multiindex[0], other.children[0].shape[0]) == bijection
+        for other in gathers)
     multiindex = _clone_multiindex(tensor.multiindex)
     replacer = MemoizerArg(filtered_replace_indices)
     mapper = MemoizerArg(_replace_gathers)
@@ -1596,7 +1651,15 @@ def _prepare_unflattening(
     ordering[tuple(points.T)] = numpy.arange(len(points))
     flat_index = VariableIndex(Indexed(
         Literal(ordering, dtype=uint_type), multiindex))
-    return mapper, multiindex, flat_index
+    if permutation is None:
+        source_index = flat_index
+    else:
+        inverse = numpy.empty(len(permutation), dtype=uint_type)
+        inverse[numpy.asarray(permutation)] = numpy.arange(
+            len(permutation), dtype=uint_type)
+        source_index = VariableIndex(Indexed(
+            Literal(inverse, dtype=uint_type), (flat_index,)))
+    return mapper, multiindex, source_index
 
 
 def _separable_sum(node: Node, indices: frozenset[Index]) -> bool:
@@ -1622,8 +1685,9 @@ def _unflatten_contracted_terms(
             leftover.append(term)
             continue
         _, _, gathers = candidate
-        mapper, multiindex, flat_index = _prepare_unflattening(gathers)
-        term = mapper(term, ((index, flat_index),))
+        mapper, multiindex, source_index = _prepare_unflattening(
+            gathers, index)
+        term = mapper(term, ((index, source_index),))
         own = frozenset(multiindex)
         predicate = partial(_separable_sum, indices=own)
         rewritten.extend(
@@ -1731,8 +1795,9 @@ def _unflatten_free_indices(
             changed = True
             index, _ = key
             gathers = tuple(OrderedDict.fromkeys(gathers))
-            mapper, multiindex, flat_index = _prepare_unflattening(gathers)
-            substitution = ((index, flat_index),)
+            mapper, multiindex, source_index = _prepare_unflattening(
+                gathers, index)
+            substitution = ((index, source_index),)
             new_variable = MemoizerArg(filtered_replace_indices)(
                 current_variable, substitution)
             new_expression = mapper(term, substitution)

--- a/gem/scheduling.py
+++ b/gem/scheduling.py
@@ -135,9 +135,11 @@ def handle(ops, push, decref, node):
     elif isinstance(node, impero.Return):
         ops.append(node)
         decref(node.expression)
+        decref(node.variable)
     elif isinstance(node, impero.ReturnAccumulate):
         ops.append(node)
         decref(node.indexsum.children[0])
+        decref(node.variable)
     else:
         raise AssertionError("no handler for node type %s" % type(node))
 
@@ -157,8 +159,10 @@ def emit_operations(assignments, get_indices, emit_return_accumulate=True):
     :returns: list of Impero terminals correctly ordered to evaluate
               the assignments
     """
-    # Prepare reference counts
-    refcount = collect_refcount([e for v, e in assignments])
+    # Prepare reference counts.  Return variables participate too: their
+    # index expressions (e.g. `gem.VariableIndex` gather tables) may need
+    # evaluating just like the right-hand sides.
+    refcount = collect_refcount([node for pair in assignments for node in pair])
 
     # Stage return operations
     staging = []

--- a/test/FIAT/unit/test_bernstein.py
+++ b/test/FIAT/unit/test_bernstein.py
@@ -20,9 +20,10 @@
 import numpy
 import pytest
 
-from FIAT.reference_element import ufc_simplex
 from FIAT.bernstein import Bernstein
+from FIAT.polynomial_set import mis
 from FIAT.quadrature_schemes import create_quadrature
+from FIAT.reference_element import multiindex_equal, ufc_simplex
 
 
 D02 = numpy.array([
@@ -74,10 +75,13 @@ def test_bernstein_2nd_derivatives():
     points = rule.get_points()
 
     actual = elem.tabulate(2, points)
+    barycentric_indices = list(mis(3, degree))
+    ordering = [barycentric_indices.index(alpha)
+                for alpha in multiindex_equal(3, degree)]
 
-    assert numpy.allclose(D02, actual[(0, 2)])
-    assert numpy.allclose(D11, actual[(1, 1)])
-    assert numpy.allclose(D20, actual[(2, 0)])
+    assert numpy.allclose(D02[ordering], actual[(0, 2)])
+    assert numpy.allclose(D11[ordering], actual[(1, 1)])
+    assert numpy.allclose(D20[ordering], actual[(2, 0)])
 
 
 if __name__ == '__main__':

--- a/test/finat/test_point_evaluation.py
+++ b/test/finat/test_point_evaluation.py
@@ -69,6 +69,48 @@ def test_point_evaluation_zany(ref_to_phys, element, degree):
         assert numpy.allclose(val, expected[alpha][:num_dof])
 
 
+@pytest.mark.parametrize("make_element", [
+    pytest.param(lambda cell, degree: finat.Legendre(cell, degree, variant="integral"),
+                 id="integral"),
+    pytest.param(finat.IntegratedLegendre, id="integrated"),
+    pytest.param(finat.Bernstein, id="bernstein"),
+])
+@pytest.mark.parametrize('degree', [1, 4])
+def test_duffy_evaluation(cell, degree, make_element):
+    from finat.point_set import PointSet, CollapsedTensorProductPointSet
+
+    dim = cell.get_spatial_dimension()
+    element = make_element(cell, degree)
+
+    # Unequal point counts per axis, including the collapsed vertex eta=1
+    factors = [PointSet(numpy.linspace(0, 1, 3 + axis)[:, None]) for axis in range(dim)]
+    ps = CollapsedTensorProductPointSet(factors)
+    duffy = element.duffy_evaluation(1, ps)
+
+    dense_ps = PointSet(ps.points)
+    expected = element.basis_evaluation(1, dense_ps)
+    assert expected.keys() == duffy.keys()
+
+    # Both tabulations use a flat dof axis.
+    ndof = element.space_dimension()
+    for alpha, table in expected.items():
+        exp, = gem.interpreter.evaluate([table])
+        exp = exp.broadcast(dense_ps.indices)
+        act, = gem.interpreter.evaluate([duffy[alpha]])
+        act = act.broadcast(ps.indices).reshape(-1, ndof)
+        assert numpy.allclose(act, exp, rtol=1E-10, atol=1E-12)
+
+        coefficients = numpy.random.default_rng(1).random(ndof)
+        index = gem.Index(extent=ndof)
+        contraction = gem.IndexSum(
+            gem.Product(gem.Indexed(gem.Literal(coefficients), (index,)),
+                        gem.Indexed(duffy[alpha], (index,))), (index,))
+        value, = gem.interpreter.evaluate([contraction])
+        value = value.broadcast(ps.indices)
+        assert numpy.allclose(value.reshape(-1), exp @ coefficients,
+                              rtol=1E-10, atol=1E-12)
+
+
 if __name__ == '__main__':
     import os
     pytest.main(os.path.abspath(__file__))

--- a/test/finat/test_quadrature.py
+++ b/test/finat/test_quadrature.py
@@ -1,6 +1,9 @@
+import numpy
 import pytest
 
+import gem
 from FIAT import ufc_cell
+from FIAT.quadrature_schemes import create_quadrature as fiat_scheme
 from finat.quadrature import make_quadrature
 
 
@@ -17,3 +20,24 @@ def test_quadrature_rules_are_hashable(cell_name):
     assert hash(quadrature1) == hash(quadrature2)
     assert repr(quadrature1) == repr(quadrature2)
     assert quadrature1 == quadrature2
+
+
+@pytest.mark.parametrize("cell_name", ["interval", "triangle", "tetrahedron"])
+@pytest.mark.parametrize("degree", [3, 8])
+def test_collapsed_quadrature(cell_name, degree):
+    ref_cell = ufc_cell(cell_name)
+    dim = ref_cell.get_spatial_dimension()
+    rule = make_quadrature(ref_cell, degree, scheme="collapsed")
+    ps = rule.point_set
+    result, = gem.interpreter.evaluate([rule.weight_expression])
+    weights = result.broadcast(ps.indices).ravel()
+
+    reference = fiat_scheme(ref_cell, degree, "canonical")
+    ref_points = reference.get_points()
+    ref_weights = reference.get_weights()
+    for alpha in numpy.ndindex((degree + 1,) * dim):
+        if sum(alpha) > degree:
+            continue
+        monomial = lambda pts: numpy.prod(pts ** numpy.asarray(alpha), axis=-1)
+        exact = numpy.dot(ref_weights, monomial(ref_points))
+        assert numpy.allclose(numpy.dot(weights, monomial(ps.points)), exact)

--- a/test/gem/test_simplify.py
+++ b/test/gem/test_simplify.py
@@ -11,10 +11,12 @@ from gem.node import traversal
 from gem.interpreter import evaluate
 from gem.optimise import (
     _distribute_sum,
+    contraction,
     eliminate_deltas,
     hoist_linear_index,
     preserve_linear_maps,
     sum_factorise,
+    unflatten_returns,
 )
 from gem.refactorise import (ATOMIC, COMPOUND, OTHER,
                              collect_factorisation_plans)
@@ -295,6 +297,144 @@ def test_delta_elimination_preserves_indirect_free_index():
     assert result.free_indices == (k,)
     actual, = evaluate([result])
     assert numpy.array_equal(actual.arr, values.array[entries])
+
+
+def test_unflatten_compatible_returns_together():
+    extent = 3
+    p = gem.Index(extent=extent)
+    q = gem.JaggedIndex(extent=extent, parents=(p,))
+    X = gem.Variable("X", (extent, extent))
+    Y = gem.Variable("Y", (extent, extent))
+    ft_x = gem.FlattenedTensor(gem.Indexed(X, (p, q)), (p, q))
+    ft_y = gem.FlattenedTensor(gem.Indexed(Y, (p, q)), (p, q))
+
+    r = gem.Index(extent=6)
+    result = gem.Variable("result", (6,))
+    pairs = unflatten_returns([
+        (gem.Indexed(result, (r,)),
+         gem.Sum(gem.Indexed(ft_x, (r,)), gem.Indexed(ft_y, (r,))))
+    ])
+
+    assert len(pairs) == 1
+    variable, expression = pairs[0]
+    assert variable.free_indices == expression.free_indices
+    assert len(variable.free_indices) == 2
+    assert not any(isinstance(node, gem.FlattenedTensor)
+                   for node in traversal((expression,)))
+
+
+def test_unflatten_factorises_local_sum():
+    extent = 3
+    p = gem.JaggedIndex(extent=extent)
+    q = gem.JaggedIndex(extent=extent, parents=(p,))
+    ip, iq = gem.indices(2)
+    A = gem.Variable("A", (extent, 2))
+    B = gem.Variable("B", (extent, extent, 2))
+    C = gem.Variable("C", (extent, 2))
+    D = gem.Variable("D", (extent, extent, 2))
+    lattice = gem.Sum(
+        gem.Product(gem.Indexed(A, (p, ip)), gem.Indexed(B, (p, q, iq))),
+        gem.Product(gem.Indexed(C, (p, ip)), gem.Indexed(D, (p, q, iq))),
+    )
+    table = gem.FlattenedTensor(lattice, (p, q))
+
+    r = gem.Index(extent=6)
+    w = gem.Variable("w", (6,))
+    expression = gem.IndexSum(
+        gem.Product(gem.Indexed(table, (r,)), gem.Indexed(w, (r,))), (r,))
+    result = contraction(expression)
+
+    sums = [node for node in traversal((result,))
+            if isinstance(node, gem.IndexSum)]
+    assert sums
+    assert all(len(node.multiindex) == 1 for node in sums)
+    assert not any(isinstance(node, gem.FlattenedTensor)
+                   for node in traversal((result,)))
+
+
+def test_unflatten_factorises_bilinear_arguments_together():
+    """Two argument lattices are exposed before their local sums expand."""
+    extent = 3
+    p = gem.JaggedIndex(extent=extent)
+    q = gem.JaggedIndex(extent=extent, parents=(p,))
+    r = gem.JaggedIndex(extent=extent)
+    s = gem.JaggedIndex(extent=extent, parents=(r,))
+    ip, iq = gem.indices(2)
+
+    variables = tuple(
+        gem.Variable(name, shape)
+        for name, shape in [
+            ("A", (extent, 2)),
+            ("B", (extent, extent, 2)),
+            ("C", (extent, 2)),
+            ("D", (extent, extent, 2)),
+            ("E", (extent, 2)),
+            ("F", (extent, extent, 2)),
+            ("G", (extent, 2)),
+            ("H", (extent, extent, 2)),
+        ])
+    A, B, C, D, E, F, G, H = variables
+    left = gem.FlattenedTensor(gem.Sum(
+        gem.Product(gem.Indexed(A, (p, ip)),
+                    gem.Indexed(B, (p, q, iq))),
+        gem.Product(gem.Indexed(C, (p, ip)),
+                    gem.Indexed(D, (p, q, iq))),
+    ), (p, q))
+    right = gem.FlattenedTensor(gem.Sum(
+        gem.Product(gem.Indexed(E, (r, ip)),
+                    gem.Indexed(F, (r, s, iq))),
+        gem.Product(gem.Indexed(G, (r, ip)),
+                    gem.Indexed(H, (r, s, iq))),
+    ), (r, s))
+
+    i, j = gem.indices(2)
+    output = gem.Variable("output", (6, 6))
+    expression = gem.IndexSum(
+        gem.Product(gem.Indexed(left, (i,)),
+                    gem.Indexed(right, (j,))),
+        (ip, iq))
+    pairs = unflatten_returns([
+        (gem.Indexed(output, (i, j)), expression)
+    ])
+
+    assert len(pairs) == 1
+    variable, optimized = pairs[0]
+    assert len(variable.free_indices) == 4
+    assert all(isinstance(index, gem.JaggedIndex)
+               for index in variable.free_indices)
+    assert not any(isinstance(node, gem.FlattenedTensor)
+                   for node in traversal((optimized,)))
+    assert all(len(node.multiindex) == 1
+               for node in traversal((optimized,))
+               if isinstance(node, gem.IndexSum))
+
+    rng = numpy.random.default_rng(2)
+    bindings = {
+        variable_: rng.random(variable_.shape)
+        for variable_ in variables
+    }
+    expected, = evaluate([expression], bindings)
+    actual, = evaluate([optimized], bindings)
+    points = left.lattice_points()
+    row_map, column_map = evaluate([
+        index.expression for index in variable.multiindex
+    ])
+    row = row_map.arr[points[:, 0], points[:, 1]]
+    column = column_map.arr[points[:, 0], points[:, 1]]
+    row_indices = {
+        index: points[:, position, None]
+        for position, index in enumerate(row_map.fids)
+    }
+    column_indices = {
+        index: points[None, :, position]
+        for position, index in enumerate(column_map.fids)
+    }
+    indices = tuple((row_indices | column_indices)[index]
+                    for index in actual.fids)
+    values = actual.arr[indices]
+    dense = numpy.empty((6, 6))
+    dense[row[:, None], column[None, :]] = values
+    assert numpy.allclose(dense, expected.broadcast((i, j)))
 
 
 def test_sum_factorise_bounded_distribution():

--- a/test/gem/test_simplify.py
+++ b/test/gem/test_simplify.py
@@ -342,6 +342,8 @@ def test_unflatten_bijective_return_index():
     ])[0]
 
     assert len(variable.free_indices) == 2
+    scatter_expression = variable.multiindex[0].expression
+    assert scatter_expression.children[0].shape == (extent, extent)
     assert not any(isinstance(node, gem.FlattenedTensor)
                    for node in traversal((optimized,)))
 

--- a/test/gem/test_simplify.py
+++ b/test/gem/test_simplify.py
@@ -323,6 +323,48 @@ def test_unflatten_compatible_returns_together():
                    for node in traversal((expression,)))
 
 
+def test_unflatten_bijective_return_index():
+    """Invert a compile-time permutation before exposing a return lattice."""
+    extent = 3
+    p = gem.Index(extent=extent)
+    q = gem.JaggedIndex(extent=extent, parents=(p,))
+    X = gem.Variable("X", (extent, extent))
+    table = gem.FlattenedTensor(
+        gem.Indexed(X, (p, q)), (p, q))
+
+    r = gem.Index(extent=6)
+    permutation = numpy.asarray([2, 0, 5, 1, 4, 3], dtype=gem.uint_type)
+    mapped = gem.Indexed(table, (gem.VariableIndex(gem.Indexed(
+        gem.Literal(permutation, dtype=gem.uint_type), (r,))),))
+    output = gem.Variable("output", (6,))
+    variable, optimized = unflatten_returns([
+        (gem.Indexed(output, (r,)), mapped)
+    ])[0]
+
+    assert len(variable.free_indices) == 2
+    assert not any(isinstance(node, gem.FlattenedTensor)
+                   for node in traversal((optimized,)))
+
+    values = numpy.arange(extent * extent, dtype=float).reshape(
+        extent, extent)
+    expected, = evaluate([mapped], {X: values})
+    actual, scatter = evaluate(
+        [optimized, variable.multiindex[0].expression], {X: values})
+    points = table.lattice_points()
+    coordinates = {
+        index: points[:, position]
+        for position, index in enumerate(variable.free_indices)
+    }
+
+    def sample(value):
+        return value.arr[tuple(coordinates[index]
+                               for index in value.fids)]
+
+    dense = numpy.empty(6)
+    dense[sample(scatter)] = sample(actual)
+    assert numpy.array_equal(dense, expected.broadcast((r,)))
+
+
 def test_unflatten_factorises_local_sum():
     extent = 3
     p = gem.JaggedIndex(extent=extent)


### PR DESCRIPTION
## Stack

- Base: firedrakeproject/fiat#276
- Paired Firedrake simplex PR: firedrakeproject/firedrake#5263
- Paired Firedrake generic base: firedrakeproject/firedrake#5335

## Summary

- add Duffy and Bernstein tabulations on collapsed simplex coordinates
- retain simplex lattice structure with `JaggedIndex` and `FlattenedTensor`
- expose compatible argument lattices jointly before scalar algebraic factorisation
- lower final simplex loops to exact parameterized domains
- apply the Duffy coefficient matrix through the generic `MappedTabulation` basis-transform path
- keep the removed `gem.sparse_matrix` implementation out of the simplex layer

The finite-element structure is explicit: build the reference Duffy tabulation, apply the coefficient or basis transformation, then contract with quadrature data.

## Current reproducible code-generation snapshot

Generated with `benchmarks/bernstein_laplacian.py` in the paired Firedrake branch:

| cell | degree | scheme | compile (s) | FLOPs | scalar temps | array temps | stored values | largest | AST lines |
| :--- | ---: | :--- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| tetrahedron | 10 | collapsed | 0.404 | 585,587,154 | 33 | 27 | 153,524 | 28,600 | 168 |
| tetrahedron | 10 | canonical | 0.366 | 576,863,054 | 29 | 7 | 859,887 | 286,000 | 106 |
| triangle | 10 | collapsed | 0.101 | 2,323,413 | 16 | 14 | 4,348 | 1,210 | 91 |
| triangle | 10 | canonical | 0.102 | 2,217,713 | 14 | 5 | 13,446 | 6,600 | 69 |

Collapsed degree-10 kernels substantially reduce stored temporary values and largest arrays, but currently cost about 1.5% more FLOPs in 3D and 4.8% more in 2D. This is retained as an explicit draft performance target.

## Validation

- `pydocstyle FIAT finat gem`
- `flake8 FIAT finat gem test`
- 68 selected GEM, Bernstein, Duffy, quadrature, and point-evaluation tests
- exact ragged-domain interpretation and generated-loop coverage

## AI assistance

OpenAI Codex was used for implementation, refactoring, testing, benchmarking, and drafting this PR. The human contributor remains responsible for understanding, validating, and maintaining the changes.
