### PR TITLE
propagate dtype through finat element construction

### DIFF
--- a/FIAT/alfeld_sorokina.py
+++ b/FIAT/alfeld_sorokina.py
@@ -6,10 +6,13 @@
 #
 # Written by Pablo D. Brubeck (brubeck@protonmail.com), 2024
 
+import copy
+
 from FIAT import finite_element, dual_set, polynomial_set
 from FIAT.functional import ComponentPointEvaluation, PointDivergence
 from FIAT.quadrature_schemes import create_quadrature
 from FIAT.macro import CkPolynomialSet, AlfeldSplit
+from FIAT.reference_element import cast_vertices
 
 import numpy
 
@@ -24,25 +27,34 @@ def AlfeldSorokinaSpace(ref_el, degree):
     num_members = C0.get_num_members()
     coeffs = C0.get_coeffs()
 
-    facet_el = ref_complex.construct_subelement(sd-1)
-    phi = polynomial_set.ONPolynomialSet(facet_el, 0 if sd == 1 else degree-1)
-    Q = create_quadrature(facet_el, 2 * phi.degree)
-    qpts, qwts = Q.get_points(), Q.get_weights()
-    phi_at_qpts = phi.tabulate(qpts)[(0,) * (sd-1)]
-    weights = numpy.multiply(phi_at_qpts, qwts)
+    interior_facets = ref_complex.get_interior_facets(sd-1)
+    if len(interior_facets) > 0:
+        # Redo this in double precision, on a copy of the actual geometry.
+        ref_el_fp64 = copy.copy(ref_el)
+        ref_el_fp64.vertices = cast_vertices(ref_el.vertices, float)
+        ref_el_fp64._split_cache = {}
+        ref_complex_fp64 = AlfeldSplit(ref_el_fp64)
+        C0_fp64 = CkPolynomialSet(ref_complex_fp64, degree, order=0, shape=(sd,), variant="bubble")
+        expansion_set_fp64 = C0_fp64.get_expansion_set()
 
-    rows = []
-    for facet in ref_complex.get_interior_facets(sd-1):
-        n = ref_complex.compute_normal(facet)
-        jumps = expansion_set.tabulate_normal_jumps(degree, qpts, facet, order=1)
-        div_jump = n[:, None, None] * jumps[1][None, ...]
-        r = numpy.tensordot(div_jump, weights, axes=(-1, -1))
-        rows.append(r.reshape(num_members, -1).T)
+        facet_el_fp64 = ref_complex_fp64.construct_subelement(sd-1)
+        phi_fp64 = polynomial_set.ONPolynomialSet(facet_el_fp64, 0 if sd == 1 else degree-1)
+        Q_fp64 = create_quadrature(facet_el_fp64, 2 * phi_fp64.degree)
+        qpts_fp64, qwts_fp64 = Q_fp64.get_points(), Q_fp64.get_weights()
+        phi_at_qpts_fp64 = phi_fp64.tabulate(qpts_fp64)[(0,) * (sd-1)]
+        weights_fp64 = numpy.multiply(phi_at_qpts_fp64, qwts_fp64)
 
-    if len(rows) > 0:
-        dual_mat = numpy.vstack(rows)
+        rows_fp64 = []
+        for facet in ref_complex_fp64.get_interior_facets(sd-1):
+            n_fp64 = ref_complex_fp64.compute_normal(facet)
+            jumps_fp64 = expansion_set_fp64.tabulate_normal_jumps(degree, qpts_fp64, facet, order=1)
+            div_jump_fp64 = n_fp64[:, None, None] * jumps_fp64[1][None, ...]
+            r_fp64 = numpy.tensordot(div_jump_fp64, weights_fp64, axes=(-1, -1))
+            rows_fp64.append(r_fp64.reshape(num_members, -1).T)
+
+        dual_mat = numpy.vstack(rows_fp64)
         nsp = polynomial_set.spanning_basis(dual_mat, nullspace=True)
-        coeffs = numpy.tensordot(nsp, coeffs, axes=(-1, 0))
+        coeffs = numpy.tensordot(nsp.astype(coeffs.dtype), coeffs, axes=(-1, 0))
     return polynomial_set.PolynomialSet(ref_complex, degree, degree, expansion_set, coeffs)
 
 

--- a/FIAT/expansions.py
+++ b/FIAT/expansions.py
@@ -9,7 +9,7 @@ to allow users to get coordinates that they want."""
 
 import numpy
 import math
-from FIAT import reference_element, jacobi
+from FIAT import precision, reference_element, jacobi
 from FIAT.precision import calibrate_tolerance
 
 
@@ -379,7 +379,9 @@ class ExpansionSet(object):
 
         if pts.dtype == object:
             # If binning is undefined, scale by the characteristic function of each subcell
-            tol = calibrate_tolerance(1E-12, numpy.array(self.ref_el.vertices).dtype)
+            ref_dtype = numpy.array(self.ref_el.vertices).dtype
+            dtype = ref_dtype if ref_dtype == numpy.dtype(numpy.float32) else precision.DEFAULT_SCALAR_DTYPE
+            tol = calibrate_tolerance(1E-12, dtype)
             Xi = compute_partition_of_unity(self.ref_el, pts, unique=unique, tol=tol)
             for cell, phi in phis.items():
                 for alpha in phi:

--- a/FIAT/expansions.py
+++ b/FIAT/expansions.py
@@ -9,7 +9,7 @@ to allow users to get coordinates that they want."""
 
 import numpy
 import math
-from FIAT import precision, reference_element, jacobi
+from FIAT import reference_element, jacobi
 from FIAT.precision import calibrate_tolerance
 
 
@@ -379,9 +379,7 @@ class ExpansionSet(object):
 
         if pts.dtype == object:
             # If binning is undefined, scale by the characteristic function of each subcell
-            ref_dtype = numpy.array(self.ref_el.vertices).dtype
-            dtype = ref_dtype if ref_dtype == numpy.dtype(numpy.float32) else precision.DEFAULT_SCALAR_DTYPE
-            tol = calibrate_tolerance(1E-12, dtype)
+            tol = calibrate_tolerance(1E-12, numpy.array(self.ref_el.vertices).dtype)
             Xi = compute_partition_of_unity(self.ref_el, pts, unique=unique, tol=tol)
             for cell, phi in phis.items():
                 for alpha in phi:

--- a/FIAT/macro.py
+++ b/FIAT/macro.py
@@ -1,3 +1,4 @@
+import copy
 from itertools import chain, combinations
 
 import numpy
@@ -528,29 +529,37 @@ def hdiv_conforming_coefficients(U, order=0):
     k = 1 if expansion_set.continuity == "C0" else 0
 
     sd = ref_el.get_spatial_dimension()
-    facet_el = ref_el.construct_subelement(sd-1)
-
     phi_deg = 0 if sd == 1 else degree - k
-    phi = polynomial_set.ONPolynomialSet(facet_el, phi_deg, shape=shape[1:])
-    Q = create_quadrature(facet_el, 2 * phi_deg)
-    qpts, qwts = Q.get_points(), Q.get_weights()
-    phi_at_qpts = phi.tabulate(qpts)[(0,) * (sd-1)]
-    weights = numpy.multiply(phi_at_qpts, qwts)
-    ax = tuple(range(1, weights.ndim))
 
-    rows = []
-    for facet in ref_el.get_interior_facets(sd-1):
-        normal = ref_el.compute_scaled_normal(facet)
-        ncoeffs = numpy.tensordot(coeffs, normal, axes=(len(shape), 0))
-        jumps = expansion_set.tabulate_normal_jumps(degree, qpts, facet, order=order)
-        for r in range(k, order+1):
-            njump = numpy.dot(ncoeffs, jumps[r])
-            rows.append(numpy.tensordot(weights, njump, axes=(ax, ax)))
+    interior_facets = ref_el.get_interior_facets(sd-1)
+    if len(interior_facets) > 0:
+        # Redo this in double precision, on a copy of the actual geometry.
+        parent_fp64 = copy.copy(ref_el.get_parent())
+        parent_fp64.vertices = reference_element.cast_vertices(parent_fp64.vertices, float)
+        parent_fp64._split_cache = {}
+        ref_complex_fp64 = type(ref_el)(parent_fp64)
+        expansion_set_fp64 = expansions.ExpansionSet(ref_complex_fp64, scale=expansion_set.scale, variant=expansion_set.variant)
+        facet_el_fp64 = ref_complex_fp64.construct_subelement(sd-1)
+        phi_fp64 = polynomial_set.ONPolynomialSet(facet_el_fp64, phi_deg, shape=shape[1:])
+        Q_fp64 = create_quadrature(facet_el_fp64, 2 * phi_deg)
+        qpts_fp64, qwts_fp64 = Q_fp64.get_points(), Q_fp64.get_weights()
+        phi_at_qpts_fp64 = phi_fp64.tabulate(qpts_fp64)[(0,) * (sd-1)]
+        weights_fp64 = numpy.multiply(phi_at_qpts_fp64, qwts_fp64)
+        ax = tuple(range(1, weights_fp64.ndim))
+        coeffs_fp64 = coeffs.astype(numpy.float64)
 
-    if len(rows) > 0:
-        dual_mat = numpy.vstack(rows)
+        rows_fp64 = []
+        for facet in ref_complex_fp64.get_interior_facets(sd-1):
+            normal_fp64 = ref_complex_fp64.compute_scaled_normal(facet)
+            ncoeffs_fp64 = numpy.tensordot(coeffs_fp64, normal_fp64, axes=(len(shape), 0))
+            jumps_fp64 = expansion_set_fp64.tabulate_normal_jumps(degree, qpts_fp64, facet, order=order)
+            for r in range(k, order+1):
+                njump_fp64 = numpy.dot(ncoeffs_fp64, jumps_fp64[r])
+                rows_fp64.append(numpy.tensordot(weights_fp64, njump_fp64, axes=(ax, ax)))
+
+        dual_mat = numpy.vstack(rows_fp64)
         nsp = polynomial_set.spanning_basis(dual_mat, nullspace=True)
-        coeffs = numpy.tensordot(nsp, coeffs, axes=(1, 0))
+        coeffs = numpy.tensordot(nsp.astype(coeffs.dtype), coeffs, axes=(1, 0))
     return coeffs
 
 

--- a/FIAT/polynomial_set.py
+++ b/FIAT/polynomial_set.py
@@ -16,6 +16,8 @@
 # an entire set of polynomials)
 
 import numpy
+
+from FIAT.precision import calibrate_tolerance
 from itertools import chain
 from FIAT import expansions
 
@@ -157,9 +159,11 @@ def form_matrix_product(mats, alpha):
     return result
 
 
-def spanning_basis(A, nullspace=False, rtol=1e-10):
+def spanning_basis(A, nullspace=False, rtol=None):
     """Construct a basis that spans the rows of A via SVD.
     """
+    if rtol is None:
+        rtol = calibrate_tolerance(1e-10, A.dtype)
     Aflat = A.reshape(A.shape[0], -1)
     u, sig, vt = numpy.linalg.svd(Aflat, full_matrices=True)
     atol = rtol * (sig[0] + 1)

--- a/FIAT/reference_element.py
+++ b/FIAT/reference_element.py
@@ -409,7 +409,8 @@ class SimplicialComplex(Cell):
         if cell is None:
             cell = next(k for k, facets in enumerate(self.connectivity[(sd, sd-1)])
                         if facet_i in facets)
-        verts = numpy.asarray(self.get_vertices_of_subcomplex(t[sd][cell]))
+        # Always compute in double precision for a robust SVD below.
+        verts = numpy.asarray(self.get_vertices_of_subcomplex(t[sd][cell]), dtype=float)
         # Interval case
         if self.get_shape() == LINE:
             v_i = t[1][cell].index(t[0][facet_i][0])
@@ -429,7 +430,7 @@ class SimplicialComplex(Cell):
             self.get_vertices_of_subcomplex(t[sd-1][facet_i])
 
         # now I find everything normal to the facet.
-        vcf = numpy.asarray(vert_coords_of_facet)
+        vcf = numpy.asarray(vert_coords_of_facet, dtype=float)
         facet_span = vcf[1:, :] - vcf[:1, :]
         (_, sf, vft) = numpy.linalg.svd(facet_span)
 

--- a/finat/element_factory.py
+++ b/finat/element_factory.py
@@ -111,13 +111,15 @@ have a direct FInAT equivalent."""
 
 
 @cache
-def as_fiat_cell(cell):
+def as_fiat_cell(cell, dtype=None):
     """Convert a ufl cell to a FIAT cell.
 
-    :arg cell: the :class:`ufl.Cell` to convert."""
+    :arg cell: the :class:`ufl.Cell` to convert.
+    :arg dtype: the dtype to build the reference cell's coordinates with.
+        Defaults to FIAT's own default (float64) if not given."""
     if not isinstance(cell, ufl.AbstractCell):
         raise ValueError("Expecting a UFL Cell")
-    return ufc_cell(cell)
+    return ufc_cell(cell, dtype=dtype)
 
 
 @singledispatch
@@ -153,7 +155,7 @@ dg_interval_variants = {
 # Base finite elements first
 @convert.register(finat.ufl.FiniteElement)
 def convert_finiteelement(element, **kwargs):
-    cell = as_fiat_cell(element.cell)
+    cell = as_fiat_cell(element.cell, dtype=kwargs.get("dtype"))
     if element.family() in {"Quadrature", "Boundary Quadrature"}:
         degree = element.degree()
         scheme = element.quadrature_scheme() or "default"
@@ -161,7 +163,7 @@ def convert_finiteelement(element, **kwargs):
             raise ValueError("Quadrature scheme and degree must be specified!")
 
         codim = 1 if element.family() == "Boundary Quadrature" else 0
-        return finat.make_quadrature_element(cell, degree, scheme, codim), set()
+        return finat.make_quadrature_element(cell, degree, scheme, codim), {"dtype"}
 
     make_finat_element = supported_elements[element.family()]
 
@@ -186,7 +188,7 @@ def convert_finiteelement(element, **kwargs):
         finat_elem, deps = _create_element(element, **kwargs)
         return finat.FlattenedDimensions(finat_elem), deps
 
-    deps = set()
+    deps = {"dtype"}
     finat_kwargs = {}
     kind = element.variant()
     if kind is None:
@@ -205,7 +207,7 @@ def convert_finiteelement(element, **kwargs):
             finat_kwargs["variant"] = kind
             finat_kwargs["shift_axes"] = kwargs["shift_axes"]
             finat_kwargs["restriction"] = kwargs["restriction"]
-            deps = {"shift_axes", "restriction"}
+            deps |= {"shift_axes", "restriction"}
         else:
             # Let FIAT handle the general case
             make_finat_element = finat.Lagrange
@@ -227,7 +229,7 @@ def convert_finiteelement(element, **kwargs):
             finat_kwargs["shift_axes"] = kwargs["shift_axes"]
             finat_kwargs["restriction"] = kwargs["restriction"]
             finat_kwargs["continuous"] = False
-            deps = {"shift_axes", "restriction"}
+            deps |= {"shift_axes", "restriction"}
         else:
             # Let FIAT handle the general case
             make_finat_element = finat.DiscontinuousLagrange
@@ -330,18 +332,21 @@ quadrilateral_tpc = ufl.TensorProductCell(ufl.interval, ufl.interval)
 _cache = weakref.WeakKeyDictionary()
 
 
-def create_element(ufl_element, shape_innermost=True, shift_axes=0, restriction=None):
+def create_element(ufl_element, shape_innermost=True, shift_axes=0, restriction=None, dtype=None):
     """Create a FInAT element (suitable for tabulating with) given a UFL element.
 
     :arg ufl_element: The UFL element to create a FInAT element from.
     :arg shape_innermost: Vector/tensor indices come after basis function indices
     :arg restriction: cell restriction in interior facet integrals
                       (only for runtime tabulated elements)
+    :arg dtype: the dtype to build the element's reference cell with.
+               Defaults to FIAT's own default (float64) if not given.
     """
     finat_element, deps = _create_element(ufl_element,
                                           shape_innermost=shape_innermost,
                                           shift_axes=shift_axes,
-                                          restriction=restriction)
+                                          restriction=restriction,
+                                          dtype=dtype)
     return finat_element
 
 

--- a/test/finat/test_create_finat_element.py
+++ b/test/finat/test_create_finat_element.py
@@ -1,3 +1,4 @@
+import numpy
 import pytest
 
 import ufl
@@ -164,6 +165,28 @@ def test_cache_hit_vector(ufl_vector_element):
     B = create_element(ufl_vector_element)
 
     assert A is B
+
+
+def test_dtype_reaches_reference_cell(ufl_element):
+    """dtype passed to create_element must reach the constructed element's
+    reference cell, not silently fall back to FIAT's float64 default."""
+    default = create_element(ufl_element)
+    single = create_element(ufl_element, dtype=numpy.float32)
+    double = create_element(ufl_element, dtype=numpy.float64)
+
+    assert numpy.array(default.cell.vertices).dtype == numpy.float64
+    assert numpy.array(single.cell.vertices).dtype == numpy.float32
+    assert numpy.array(double.cell.vertices).dtype == numpy.float64
+
+
+def test_dtype_cache_distinguishes(ufl_element):
+    """Different dtypes for the same UFL element must not share a cache entry."""
+    single_a = create_element(ufl_element, dtype=numpy.float32)
+    single_b = create_element(ufl_element, dtype=numpy.float32)
+    double = create_element(ufl_element, dtype=numpy.float64)
+
+    assert single_a is single_b
+    assert single_a is not double
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
follow-up to #260
`as_fiat_cell` / `convert_finiteelement` / `create_element` in `finat/element_factory.py` now take a `dtype` and forward it to `ufc_cell`, so `ref_el.vertices` is built at the caller's actual precision.

firedrake side: firedrakeproject/firedrake#5033