### PR TITLE
Changes to FIAT to enable FUSE

### DIFF
--- a/FIAT/discontinuous_pc.py
+++ b/FIAT/discontinuous_pc.py
@@ -7,29 +7,17 @@
 # Modified by David A. Ham (david.ham@imperial.ac.uk), 2018
 
 from FIAT import finite_element, polynomial_set, dual_set, functional
-from FIAT.reference_element import (Point,
-                                    DefaultLine,
-                                    UFCInterval,
-                                    UFCQuadrilateral,
-                                    UFCHexahedron,
-                                    UFCTriangle,
-                                    UFCTetrahedron,
-                                    make_affine_mapping,
-                                    flatten_reference_cube)
+from FIAT.reference_element import (make_affine_mapping,
+                                    flatten_reference_cube,
+                                    cell_to_simplex)
 from FIAT.P0 import P0Dual
 import numpy as np
-
-hypercube_simplex_map = {Point(): Point(),
-                         DefaultLine(): DefaultLine(),
-                         UFCInterval(): UFCInterval(),
-                         UFCQuadrilateral(): UFCTriangle(),
-                         UFCHexahedron(): UFCTetrahedron()}
 
 
 class DPC0(finite_element.CiarletElement):
     def __init__(self, ref_el):
         flat_el = flatten_reference_cube(ref_el)
-        poly_set = polynomial_set.ONPolynomialSet(hypercube_simplex_map[flat_el], 0)
+        poly_set = polynomial_set.ONPolynomialSet(cell_to_simplex(flat_el), 0)
         dual = P0Dual(ref_el)
         # Implement entity_permutations when we handle that for HigherOrderDPC.
         # Currently, orientation_tuples in P0Dual(ref_el).entity_permutations
@@ -58,7 +46,7 @@ class DPCDualSet(dual_set.DualSet):
 
         # Change coordinates here.
         # Vertices of the simplex corresponding to the reference element.
-        v_simplex = hypercube_simplex_map[flat_el].get_vertices()
+        v_simplex = cell_to_simplex(flat_el).get_vertices()
         # Vertices of the reference element.
         v_hypercube = flat_el.get_vertices()
         # For the mapping, first two vertices are unchanged in all dimensions.
@@ -74,12 +62,12 @@ class DPCDualSet(dual_set.DualSet):
 
         # make nodes by getting points
         # need to do this dimension-by-dimension, facet-by-facet
-        top = hypercube_simplex_map[flat_el].get_topology()
+        top = cell_to_simplex(flat_el).get_topology()
 
         cur = 0
         for dim in sorted(top):
             for entity in sorted(top[dim]):
-                pts_cur = hypercube_simplex_map[flat_el].make_points(dim, entity, degree)
+                pts_cur = cell_to_simplex(flat_el).make_points(dim, entity, degree)
                 pts_cur = [tuple(np.matmul(A, np.array(x)) + b) for x in pts_cur]
                 nodes_cur = [functional.PointEvaluation(flat_el, x)
                              for x in pts_cur]
@@ -102,7 +90,7 @@ class HigherOrderDPC(finite_element.CiarletElement):
 
     def __init__(self, ref_el, degree):
         flat_el = flatten_reference_cube(ref_el)
-        poly_set = polynomial_set.ONPolynomialSet(hypercube_simplex_map[flat_el], degree)
+        poly_set = polynomial_set.ONPolynomialSet(cell_to_simplex(flat_el), degree)
         dual = DPCDualSet(ref_el, flat_el, degree)
         formdegree = flat_el.get_spatial_dimension()  # n-form
         super().__init__(poly_set=poly_set,

--- a/FIAT/orientation_utils.py
+++ b/FIAT/orientation_utils.py
@@ -97,7 +97,7 @@ def _make_axis_perms_tensorproduct(cells, dim):
     This is the single sources of extrinsic orientations and corresponding axis permutations.
 
     """
-    from FIAT.reference_element import UFCInterval
+    from FIAT.reference_element import LINE
 
     # Handle extrinsic orientations.
     # This is complex and we need to think to make this function more general.
@@ -116,8 +116,8 @@ def _make_axis_perms_tensorproduct(cells, dim):
         #          dim == (2, 1) ->
         #          triangle x interval (1 possible extrinsic orientation).
         axis_perms = (tuple(range(nprod)), )  # Identity: no permutations
-    elif len(set(cells)) == 1 and isinstance(cells[0], UFCInterval):
-        # Tensor product of intervals.
+    elif len(set(cells)) == 1 and cells[0].get_shape() == LINE:
+        # Tensor product of intervals (any 1D reference cell implementation)
         # Example: interval x interval x interval x interval
         #          dim == (0, 1, 1, 1) ->
         #          point x interval x interval x interval  (1! * 3! possible extrinsic orientations).

--- a/FIAT/reference_element.py
+++ b/FIAT/reference_element.py
@@ -145,7 +145,7 @@ class Cell:
         self.vertices = vertices
         self.topology = topology
 
-        if sub_entities:
+        if sub_entities is not None:
             self.sub_entities = sub_entities
         else:
             # If sub entity list not provided
@@ -1332,7 +1332,7 @@ class TensorProductCell(Cell):
         if isinstance(other, TensorProductCell):
             return all(op(a, b) for a, b in zip(self.cells, other.cells))
         else:
-            if op == operator.gt or op == operator.lt or operator.ne:
+            if op == operator.gt or op == operator.lt or op == operator.ne:
                 return not op(other, self)
             if op == operator.ge or op == operator.le:
                 return not op(other, self) or operator.eq(self, other)

--- a/FIAT/reference_element.py
+++ b/FIAT/reference_element.py
@@ -529,7 +529,6 @@ class SimplicialComplex(Cell):
         include in each direction."""
         if dim == 0:
             return (self.get_vertices()[self.get_topology()[dim][entity_id][0]],)
-            # return (self.get_vertices()[entity_id], )
         elif 0 < dim <= self.get_spatial_dimension():
             entity_verts = \
                 self.get_vertices_of_subcomplex(
@@ -1332,10 +1331,10 @@ class TensorProductCell(Cell):
         if isinstance(other, TensorProductCell):
             return all(op(a, b) for a, b in zip(self.cells, other.cells))
         else:
-            if op == operator.gt or op == operator.lt or operator.ne:
-                return not op(other, self)
-            if op == operator.ge or op == operator.le:
-                return not op(other, self) or operator.eq(self, other)
+            #if op == operator.gt or op == operator.lt or operator.ne:
+            #    return not op(other, self)
+            #if op == operator.ge or op == operator.le:
+            #    return not op(other, self) or operator.eq(self, other)
             raise ValueError("Unknown operator in cell comparison")
 
     def __gt__(self, other):

--- a/FIAT/reference_element.py
+++ b/FIAT/reference_element.py
@@ -387,14 +387,14 @@ class SimplicialComplex(Cell):
 
     This consists of list of vertex locations and a topology map defining facets.
     """
-    def __init__(self, shape, vertices, topology, sub_ents=None):
+    def __init__(self, shape, vertices, topology, sub_entities=None):
         # Make sure that every facet has the right number of vertices to be
         # a simplex.
         for dim in topology:
             for entity in topology[dim]:
                 assert len(topology[dim][entity]) == dim + 1
 
-        super().__init__(shape, vertices, topology, sub_ents)
+        super().__init__(shape, vertices, topology, sub_entities)
 
     def compute_normal(self, facet_i, cell=None):
         """Returns the unit normal vector to facet i of codimension 1."""

--- a/FIAT/reference_element.py
+++ b/FIAT/reference_element.py
@@ -152,35 +152,18 @@ class Cell:
             # Given the topology, work out for each entity in the cell,
             # which other entities it contains.
             self.sub_entities = {}
-            self.sub_entities_old = {}
             for dim, entities in topology.items():
                 self.sub_entities[dim] = {}
-                self.sub_entities_old[dim] = {}
 
                 for e, v in entities.items():
                     vertices = frozenset(v)
                     sub_entities = []
-                    sub_entities_old = []
                     for dim_, entities_ in topology.items():
                         for e_, vertices_ in entities_.items():
                             if vertices.issuperset(vertices_):
-                                sub_entities_old.append((dim_, e_))
+                                sub_entities.append((dim_, e_))
 
-                        # in order to maintain ordering, extract subentities from vertex numbering
-                        entities_of_dim_ = list(entities_.values())
-
-                        from itertools import permutations
-                        # generate all possible sub entities
-                        sub_list = permutations(v, len(entities_of_dim_[0]))
-                        for s in sub_list:
-                            # add the sub entities in the same order as in topology
-                            for i, val in entities_.items():
-                                if set(s) == set(val) and (dim_, i) not in sub_entities:
-                                    sub_entities.append((dim_, i))
-
-                    self.sub_entities[dim][e] = list(sub_entities)
-                    self.sub_entities_old[dim][e] = list(sub_entities_old)
-                self.sub_entities = self.sub_entities_old
+                    self.sub_entities[dim][e] = sorted(list(sub_entities))
         # Build super-entity dictionary by inverting the sub-entity dictionary
         self.super_entities = {dim: {entity: [] for entity in topology[dim]} for dim in topology}
         for dim0 in topology:

--- a/FIAT/reference_element.py
+++ b/FIAT/reference_element.py
@@ -1328,10 +1328,10 @@ class TensorProductCell(Cell):
         This is done dimension by dimension."""
         if hasattr(other, "product"):
             other = other.product
-        if isinstance(other, TensorProductCell):
+        if isinstance(other, type(self)):
             return all(op(a, b) for a, b in zip(self.cells, other.cells))
         else:
-            raise ValueError("Unknown operator in cell comparison")
+            return op(self, other)
 
     def __gt__(self, other):
         return self.compare(operator.gt, other)

--- a/FIAT/reference_element.py
+++ b/FIAT/reference_element.py
@@ -1331,10 +1331,6 @@ class TensorProductCell(Cell):
         if isinstance(other, TensorProductCell):
             return all(op(a, b) for a, b in zip(self.cells, other.cells))
         else:
-            #if op == operator.gt or op == operator.lt or operator.ne:
-            #    return not op(other, self)
-            #if op == operator.ge or op == operator.le:
-            #    return not op(other, self) or operator.eq(self, other)
             raise ValueError("Unknown operator in cell comparison")
 
     def __gt__(self, other):

--- a/finat/__init__.py
+++ b/finat/__init__.py
@@ -8,7 +8,8 @@ from .fiat_elements import (Bernstein, Bubble, BrezziDouglasFortinMarini,       
                             Lagrange, Real, Serendipity,                                     # noqa: F401
                             TrimmedSerendipityCurl, TrimmedSerendipityDiv,                   # noqa: F401
                             TrimmedSerendipityEdge, TrimmedSerendipityFace,                  # noqa: F401
-                            Nedelec, NedelecSecondKind, RaviartThomas, Regge)                # noqa: F401
+                            Nedelec, NedelecSecondKind, RaviartThomas, Regge,                # noqa: F401
+                            FuseElement)                                                     # noqa: F401
 from .spectral import (GaussLobattoLegendre, GaussLegendre, KongMulderVeldhuizen,            # noqa: F401
                        Legendre, IntegratedLegendre,                                         # noqa: F401
                        FDMLagrange, FDMQuadrature, FDMDiscontinuousLagrange,                 # noqa: F401

--- a/finat/element_factory.py
+++ b/finat/element_factory.py
@@ -109,15 +109,24 @@ FInAT-equivalent constructors.  If the value is ``None``, the UFL
 element is supported, but must be handled specially because it doesn't
 have a direct FInAT equivalent."""
 
+hexahedron_tpc = ufl.TensorProductCell(ufl.interval, ufl.interval, ufl.interval)
+quadrilateral_tpc = ufl.TensorProductCell(ufl.interval, ufl.interval)
+
 
 @cache
 def as_fiat_cell(cell):
     """Convert a ufl cell to a FIAT cell.
 
     :arg cell: the :class:`ufl.Cell` to convert."""
+    if isinstance(cell, str):
+        cell = finat.ufl.as_cell(cell)
     if not isinstance(cell, ufl.AbstractCell):
         raise ValueError("Expecting a UFL Cell")
-    return ufc_cell(cell)
+
+    if hasattr(cell, "to_fiat"):
+        return cell.to_fiat()
+    else:
+        return ufc_cell(cell)
 
 
 @singledispatch
@@ -325,12 +334,15 @@ def convert_restrictedelement(element, **kwargs):
     return finat.RestrictedElement(finat_elem, element.restriction_domain()), deps
 
 
-hexahedron_tpc = ufl.TensorProductCell(ufl.interval, ufl.interval, ufl.interval)
-quadrilateral_tpc = ufl.TensorProductCell(ufl.interval, ufl.interval)
+@convert.register(finat.ufl.FuseElement)
+def convert_fuse_element(element, **kwargs):
+    return finat.fiat_elements.FuseElement(element.triple), set()
+
+
 _cache = weakref.WeakKeyDictionary()
 
 
-def create_element(ufl_element, shape_innermost=True, shift_axes=0, restriction=None):
+def create_element(ufl_element, shape_innermost=True, shift_axes=0, restriction=None, use_fuse=False):
     """Create a FInAT element (suitable for tabulating with) given a UFL element.
 
     :arg ufl_element: The UFL element to create a FInAT element from.
@@ -341,7 +353,8 @@ def create_element(ufl_element, shape_innermost=True, shift_axes=0, restriction=
     finat_element, deps = _create_element(ufl_element,
                                           shape_innermost=shape_innermost,
                                           shift_axes=shift_axes,
-                                          restriction=restriction)
+                                          restriction=restriction,
+                                          use_fuse=use_fuse)
     return finat_element
 
 

--- a/finat/element_factory.py
+++ b/finat/element_factory.py
@@ -342,20 +342,20 @@ def convert_fuse_element(element, **kwargs):
 _cache = weakref.WeakKeyDictionary()
 
 
-def create_element(ufl_element, shape_innermost=True, shift_axes=0, restriction=None, use_fuse=False):
+def create_element(ufl_element, shape_innermost=True, shift_axes=0, restriction=None, cell_backend=finat.ufl.CellBackend.FIAT):
     """Create a FInAT element (suitable for tabulating with) given a UFL element.
 
     :arg ufl_element: The UFL element to create a FInAT element from.
     :arg shape_innermost: Vector/tensor indices come after basis function indices
     :arg restriction: cell restriction in interior facet integrals
                       (only for runtime tabulated elements)
-    :arg use_fuse: When creating cells, ensure they are fuse compatible. inherited from the mesh.
+    :arg cell_backend: Enum determining the default cell type to use.
     """
     finat_element, deps = _create_element(ufl_element,
                                           shape_innermost=shape_innermost,
                                           shift_axes=shift_axes,
                                           restriction=restriction,
-                                          use_fuse=use_fuse)
+                                          cell_backend=cell_backend)
     return finat_element
 
 

--- a/finat/element_factory.py
+++ b/finat/element_factory.py
@@ -349,6 +349,7 @@ def create_element(ufl_element, shape_innermost=True, shift_axes=0, restriction=
     :arg shape_innermost: Vector/tensor indices come after basis function indices
     :arg restriction: cell restriction in interior facet integrals
                       (only for runtime tabulated elements)
+    :arg use_fuse: When creating cells, ensure they are fuse compatible. inherited from the mesh.
     """
     finat_element, deps = _create_element(ufl_element,
                                           shape_innermost=shape_innermost,

--- a/finat/fiat_elements.py
+++ b/finat/fiat_elements.py
@@ -439,3 +439,8 @@ class Nedelec(VectorFiatElement):
 class NedelecSecondKind(VectorFiatElement):
     def __init__(self, cell, degree, **kwargs):
         super().__init__(FIAT.NedelecSecondKind(cell, degree, **kwargs))
+
+
+class FuseElement(FiatElement):
+    def __init__(self, triple):
+        super(FuseElement, self).__init__(triple.to_fiat())

--- a/finat/ufl/__init__.py
+++ b/finat/ufl/__init__.py
@@ -14,8 +14,9 @@
 from finat.ufl.brokenelement import BrokenElement  # noqa: F401
 from finat.ufl.enrichedelement import EnrichedElement, NodalEnrichedElement  # noqa: F401
 from finat.ufl.finiteelement import FiniteElement  # noqa: F401
-from finat.ufl.finiteelementbase import FiniteElementBase  # noqa: F401
+from finat.ufl.finiteelementbase import FiniteElementBase, as_cell  # noqa: F401
 from finat.ufl.hdivcurl import HCurlElement, HDivElement, WithMapping, HDiv, HCurl  # noqa: F401
 from finat.ufl.mixedelement import MixedElement, TensorElement, VectorElement  # noqa: F401
 from finat.ufl.restrictedelement import RestrictedElement  # noqa: F401
 from finat.ufl.tensorproductelement import TensorProductElement  # noqa: F401
+from finat.ufl.fuseelement import FuseElement  # noqa: F401

--- a/finat/ufl/__init__.py
+++ b/finat/ufl/__init__.py
@@ -14,7 +14,7 @@
 from finat.ufl.brokenelement import BrokenElement  # noqa: F401
 from finat.ufl.enrichedelement import EnrichedElement, NodalEnrichedElement  # noqa: F401
 from finat.ufl.finiteelement import FiniteElement  # noqa: F401
-from finat.ufl.finiteelementbase import FiniteElementBase, as_cell  # noqa: F401
+from finat.ufl.finiteelementbase import FiniteElementBase, as_cell, CellBackend  # noqa: F401
 from finat.ufl.hdivcurl import HCurlElement, HDivElement, WithMapping, HDiv, HCurl  # noqa: F401
 from finat.ufl.mixedelement import MixedElement, TensorElement, VectorElement  # noqa: F401
 from finat.ufl.restrictedelement import RestrictedElement  # noqa: F401

--- a/finat/ufl/elementlist.py
+++ b/finat/ufl/elementlist.py
@@ -418,6 +418,8 @@ def canonical_element_description(family, cell, order, form_degree):
 
     # Check that the element family exists
     if family not in ufl_elements:
+        if repr(family).startswith("FuseTriple"):
+            raise ValueError("Recieved unconverted FUSE triple - did you forget to call to_ufl()?")
         raise ValueError(f"Unknown finite element '{family}'.")
 
     # Check that element data is valid (and also get common family

--- a/finat/ufl/elementlist.py
+++ b/finat/ufl/elementlist.py
@@ -18,6 +18,7 @@ elements by calling the function register_element.
 # Modified by Pablo Brubeck, 2024
 
 import warnings
+import inspect
 
 from numpy import asarray
 
@@ -417,8 +418,8 @@ def canonical_element_description(family, cell, order, form_degree):
         (family, order) = aliases[family](family, tdim, order, form_degree)
 
     # Check that we don't have a raw FUSE object
-    if repr(family).startswith("FuseTriple"):
-        raise ValueError("Recieved unconverted FUSE triple - did you forget to call to_ufl()?")
+    if not isinstance(family, str) and 'fuse' in inspect.getmodule(family).__name__:
+        raise ValueError("Received unconverted FUSE triple - did you forget to call to_ufl()?")
 
     # Check that the element family exists
     if family not in ufl_elements:

--- a/finat/ufl/elementlist.py
+++ b/finat/ufl/elementlist.py
@@ -416,10 +416,12 @@ def canonical_element_description(family, cell, order, form_degree):
             raise ValueError("Need dimension to handle element aliases.")
         (family, order) = aliases[family](family, tdim, order, form_degree)
 
+    # Check that we don't have a raw FUSE object
+    if repr(family).startswith("FuseTriple"):
+        raise ValueError("Recieved unconverted FUSE triple - did you forget to call to_ufl()?")
+
     # Check that the element family exists
     if family not in ufl_elements:
-        if repr(family).startswith("FuseTriple"):
-            raise ValueError("Recieved unconverted FUSE triple - did you forget to call to_ufl()?")
         raise ValueError(f"Unknown finite element '{family}'.")
 
     # Check that element data is valid (and also get common family

--- a/finat/ufl/finiteelement.py
+++ b/finat/ufl/finiteelement.py
@@ -11,9 +11,9 @@
 # Modified by Massimiliano Leoni, 2016
 # Modified by Matthew Scroggs, 2023
 
-from ufl.cell import TensorProductCell, as_cell
+from ufl.cell import TensorProductCell
 from finat.ufl.elementlist import canonical_element_description, simplices
-from finat.ufl.finiteelementbase import FiniteElementBase
+from finat.ufl.finiteelementbase import FiniteElementBase, as_cell
 from ufl.utils.formatting import istr
 
 

--- a/finat/ufl/finiteelementbase.py
+++ b/finat/ufl/finiteelementbase.py
@@ -278,8 +278,10 @@ def as_cell(cell: AbstractCell | str | tuple[AbstractCell, ...], use_fuse: bool 
     if isinstance(cell, str) and use_fuse:
         try:
             import fuse
-        except ModuleNotFoundError:
-            raise ModuleNotFoundError("Cannot create FUSE cell without FUSE")
+        except ModuleNotFoundError as exc:
+            raise ModuleNotFoundError(
+                "FUSE cell construction requires the optional 'fuse' dependency. "
+            ) from exc
         return fuse.constructCellComplex(cell)
     else:
         return as_cell_ufl(cell)

--- a/finat/ufl/finiteelementbase.py
+++ b/finat/ufl/finiteelementbase.py
@@ -293,9 +293,11 @@ class FiniteElementBase(AbstractFiniteElement):
         except KeyError:
             raise ValueError(f"Unsupported mapping: {self.mapping()}")
 
+
 class CellBackend(Enum):
     FIAT = 1
     FUSE = 2
+
 
 def as_cell(cell: AbstractCell | str | tuple[AbstractCell, ...], cell_backend: CellBackend = CellBackend.FIAT) -> AbstractCell:
     if isinstance(cell, str) and cell_backend == CellBackend.FUSE:

--- a/finat/ufl/finiteelementbase.py
+++ b/finat/ufl/finiteelementbase.py
@@ -14,6 +14,7 @@
 from abc import abstractmethod, abstractproperty
 from hashlib import md5
 from typing import Sequence, Union
+from enum import Enum
 
 from ufl import pullback
 from ufl.cell import AbstractCell, as_cell as as_cell_ufl
@@ -292,9 +293,12 @@ class FiniteElementBase(AbstractFiniteElement):
         except KeyError:
             raise ValueError(f"Unsupported mapping: {self.mapping()}")
 
+class CellBackend(Enum):
+    FIAT = 1
+    FUSE = 2
 
-def as_cell(cell: AbstractCell | str | tuple[AbstractCell, ...], use_fuse: bool = False) -> AbstractCell:
-    if isinstance(cell, str) and use_fuse:
+def as_cell(cell: AbstractCell | str | tuple[AbstractCell, ...], cell_backend: CellBackend = CellBackend.FIAT) -> AbstractCell:
+    if isinstance(cell, str) and cell_backend == CellBackend.FUSE:
         try:
             import fuse
         except ModuleNotFoundError as exc:

--- a/finat/ufl/finiteelementbase.py
+++ b/finat/ufl/finiteelementbase.py
@@ -15,7 +15,7 @@ from abc import abstractmethod, abstractproperty
 from hashlib import md5
 
 from ufl import pullback
-from ufl.cell import AbstractCell, as_cell
+from ufl.cell import AbstractCell, as_cell as as_cell_ufl
 from ufl.finiteelement import AbstractFiniteElement
 from ufl.utils.sequences import product
 
@@ -272,3 +272,14 @@ class FiniteElementBase(AbstractFiniteElement):
             return supported_pullbacks[self.mapping()]
         except KeyError:
             raise ValueError(f"Unsupported mapping: {self.mapping()}")
+
+
+def as_cell(cell: AbstractCell | str | tuple[AbstractCell, ...], use_fuse: bool = False) -> AbstractCell:
+    if isinstance(cell, str) and use_fuse:
+        try:
+            import fuse
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError("Cannot create FUSE cell without FUSE")
+        return fuse.constructCellComplex(cell)
+    else:
+        return as_cell_ufl(cell)

--- a/finat/ufl/fuseelement.py
+++ b/finat/ufl/fuseelement.py
@@ -11,17 +11,26 @@ class FuseElement(FiniteElementBase):
     """
     A finite element defined using FUSE.
 
-    TODO: Need to deal with cases where value shape and reference value shape are different
+    :arg triple: An ElementTriple object defined with FUSE
+    :arg cell: Optional (defaults to triple.cell) The cell the element is defined on
+
     """
 
     def __init__(self, triple, cell=None):
+        try:
+            import fuse
+        except ModuleNotFoundError as exc:
+            raise ModuleNotFoundError(
+                "FUSE element creation requires the optional 'fuse' dependency. "
+            ) from exc
+        assert isinstance(triple, fuse.ElementTriple)
         self.triple = triple
         if not cell:
             cell = self.triple.cell.to_ufl()
 
         degree = self.triple.degree
         self.sobolev_space = self.triple.spaces[1].to_ufl()
-        super(FuseElement, self).__init__("IT", cell, degree, None, triple.get_value_shape())
+        super().__init__("IT", cell, degree, None, triple.get_value_shape())
 
     def __repr__(self):
         return repr(self.triple)

--- a/finat/ufl/fuseelement.py
+++ b/finat/ufl/fuseelement.py
@@ -1,0 +1,44 @@
+"""Element."""
+# -*- coding: utf-8 -*-
+# Copyright (C) 2025 India Marsden
+#
+# SPDX-License-Identifier:    LGPL-3.0-or-later
+
+from finat.ufl.finiteelementbase import FiniteElementBase
+
+
+class FuseElement(FiniteElementBase):
+    """
+    A finite element defined using FUSE.
+
+    TODO: Need to deal with cases where value shape and reference value shape are different
+    """
+
+    def __init__(self, triple, cell=None):
+        self.triple = triple
+        if not cell:
+            cell = self.triple.cell.to_ufl()
+
+        degree = self.triple.degree
+        self.sobolev_space = self.triple.spaces[1].to_ufl()
+        super(FuseElement, self).__init__("IT", cell, degree, None, triple.get_value_shape())
+
+    def __repr__(self):
+        return repr(self.triple)
+
+    def __str__(self):
+        return "<Fuse%sElem on %s>" % (self.triple.spaces[0], self.triple.cell)
+
+    def mapping(self):
+        if str(self.sobolev_space) == "HCurl":
+            return "covariant Piola"
+        elif str(self.sobolev_space) == "HDiv":
+            return "contravariant Piola"
+        else:
+            return "identity"
+
+    def sobolev_space(self):
+        return self.triple.spaces[1]
+
+    def reconstruct(self, family=None, cell=None, degree=None, quad_scheme=None, variant=None):
+        return FuseElement(self.triple, cell=cell)

--- a/finat/ufl/fuseelement.py
+++ b/finat/ufl/fuseelement.py
@@ -30,13 +30,13 @@ class FuseElement(FiniteElementBase):
 
         degree = self.triple.degree
         self.sobolev_space = self.triple.spaces[1].to_ufl()
-        super().__init__("IT", cell, degree, None, triple.get_value_shape())
+        super().__init__("FUSE", cell, degree, None, triple.get_value_shape())
 
     def __repr__(self):
         return repr(self.triple)
 
     def __str__(self):
-        return "<Fuse%sElem on %s>" % (self.triple.spaces[0], self.triple.cell)
+        return f"<FuseElem on {self.triple.cell}>"
 
     def mapping(self):
         if str(self.sobolev_space) == "HCurl":

--- a/finat/ufl/fuseelement.py
+++ b/finat/ufl/fuseelement.py
@@ -29,7 +29,6 @@ class FuseElement(FiniteElementBase):
             cell = self.triple.cell.to_ufl()
 
         degree = self.triple.degree
-        self.sobolev_space = self.triple.spaces[1].to_ufl()
         super().__init__("IT", cell, degree, None, triple.get_value_shape())
 
     def __repr__(self):
@@ -38,16 +37,13 @@ class FuseElement(FiniteElementBase):
     def __str__(self):
         return "<Fuse%sElem on %s>" % (self.triple.spaces[0], self.triple.cell)
 
-    def mapping(self):
-        if str(self.sobolev_space) == "HCurl":
-            return "covariant Piola"
-        elif str(self.sobolev_space) == "HDiv":
-            return "contravariant Piola"
-        else:
-            return "identity"
-
+    @property
     def sobolev_space(self):
-        return self.triple.spaces[1]
+        return self.triple.spaces[2].ufl_sobolev_space(self.triple.form_degree,
+                                                       self.triple.cell.dim())
+
+    def mapping(self):
+        return self.triple.spaces[2].mapping()
 
     def reconstruct(self, family=None, cell=None, degree=None, quad_scheme=None, variant=None):
         return FuseElement(self.triple, cell=cell)

--- a/finat/ufl/mixedelement.py
+++ b/finat/ufl/mixedelement.py
@@ -13,10 +13,10 @@
 
 import numpy as np
 
-from ufl.cell import CellSequence, as_cell
+from ufl.cell import CellSequence
 from ufl.domain import MeshSequence
 from finat.ufl.finiteelement import FiniteElement
-from finat.ufl.finiteelementbase import FiniteElementBase
+from finat.ufl.finiteelementbase import FiniteElementBase, as_cell
 from ufl.permutation import compute_indices
 from ufl.pullback import MixedPullback, SymmetricPullback
 from ufl.utils.indexflattening import flatten_multiindex, shape_to_strides, unflatten_index

--- a/finat/ufl/tensorproductelement.py
+++ b/finat/ufl/tensorproductelement.py
@@ -13,8 +13,9 @@
 
 from itertools import chain
 
-from ufl.cell import TensorProductCell, as_cell
-from finat.ufl.finiteelementbase import FiniteElementBase
+from ufl.cell import TensorProductCell
+from finat.ufl.finiteelementbase import FiniteElementBase, as_cell
+
 from ufl.sobolevspace import DirectionalSobolevSpace
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ dependencies = [
   "scipy",
   "symengine",
   "sympy",
-  "fuse-element @ git+https://github.com/firedrakeproject/fuse.git",
 ]
 requires-python = ">=3.11"
 authors = [
@@ -35,6 +34,9 @@ doc = [
   "sphinx",
 ]
 test = ["pytest"]
+fuse = [
+  "fuse-element @ git+https://github.com/firedrakeproject/fuse.git",
+]
 
 [tool.setuptools]
 packages = ["FIAT", "finat", "finat.ufl", "gem"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
   "scipy",
   "symengine",
   "sympy",
+  "fuse-element @ git+https://github.com/firedrakeproject/fuse.git",
 ]
 requires-python = ">=3.11"
 authors = [

--- a/test/FIAT/unit/test_reference_element.py
+++ b/test/FIAT/unit/test_reference_element.py
@@ -22,6 +22,7 @@ import sys
 from FIAT.reference_element import UFCInterval, UFCTriangle, UFCTetrahedron
 from FIAT.reference_element import Point, TensorProductCell, UFCQuadrilateral, UFCHexahedron
 from FIAT.reference_element import is_ufc, is_hypercube, default_simplex, flatten_reference_cube, Hypercube
+from FIAT.reference_element import Cell
 
 point = Point()
 interval = UFCInterval()
@@ -84,6 +85,51 @@ def test_ufc_connectivity_Dx(cell):
         connectivity = cell.get_connectivity()[(D, dim1)]
         assert len(connectivity) == 1
         assert connectivity[0] == tuple(range(len(connectivity[0])))
+
+
+def test_explicit_sub_entities_reproduces_default():
+    """An explicit sub_entities mapping equal to the one Cell would
+    compute automatically must produce identical super_entities and
+    connectivity."""
+    topology = {0: {0: (0,), 1: (1,)}, 1: {0: (0, 1)}}
+    vertices = ((0.0,), (1.0,))
+
+    reference = Cell("interval", vertices, topology)
+    explicit = Cell("interval", vertices, topology,
+                    sub_entities=reference.sub_entities)
+
+    assert explicit.sub_entities == reference.sub_entities
+    assert explicit.super_entities == reference.super_entities
+    assert explicit.connectivity == reference.connectivity
+
+
+def test_explicit_sub_entities_custom_mapping():
+    """A deliberately different (but self-consistent) explicit
+    sub_entities mapping should be used as-is, and super_entities /
+    connectivity should be derived from it rather than recomputed
+    from the topology."""
+    topology = {0: {0: (0,), 1: (1,)}, 1: {0: (0, 1)}}
+    vertices = ((0.0,), (1.0,))
+
+    # Deliberately omit the "each entity is a sub-entity of itself"
+    # entries that the automatic computation would include.
+    custom_sub_entities = {
+        0: {0: [], 1: []},
+        1: {0: [(0, 0), (0, 1)]},
+    }
+
+    cell = Cell("interval", vertices, topology,
+                sub_entities=custom_sub_entities)
+
+    assert cell.sub_entities == custom_sub_entities
+    assert cell.super_entities == {
+        0: {0: [(1, 0)], 1: [(1, 0)]},
+        1: {0: []},
+    }
+    assert cell.connectivity[(1, 0)] == [(0, 1)]
+    assert cell.connectivity[(0, 1)] == [(0,), (0,)]
+    assert cell.connectivity[(1, 1)] == [()]
+    assert cell.connectivity[(0, 0)] == [(), ()]
 
 
 @pytest.mark.parametrize(('cell', 'volume'),


### PR DESCRIPTION
Minimal changes to enable FUSE in FIAT.

Key changes:
 - Avoiding specific references to UFC cells 
 - Lists of subentities can optionally be passed to reference cells
 - FUSE infrastructure for element creation at FIAT, finat and UFL level. Most notably the inclusion of `use_fuse` and FuseElement. `use_fuse` is derived from the Firedrake mesh. 
 - Moves `as_cell` into FIAT from UFL so that we can delegate to fuse creation as appropriate. Falls back to UFL implementation in all other cases.

Tested in firedrake on [Firedrake PR #5276](https://github.com/firedrakeproject/firedrake/pull/5276) and FUSE main sits on this branch.