### PR TITLE
FUSE elements with automatic zany

### DIFF
--- a/FIAT/discontinuous_pc.py
+++ b/FIAT/discontinuous_pc.py
@@ -7,29 +7,17 @@
 # Modified by David A. Ham (david.ham@imperial.ac.uk), 2018
 
 from FIAT import finite_element, polynomial_set, dual_set, functional
-from FIAT.reference_element import (Point,
-                                    DefaultLine,
-                                    UFCInterval,
-                                    UFCQuadrilateral,
-                                    UFCHexahedron,
-                                    UFCTriangle,
-                                    UFCTetrahedron,
-                                    make_affine_mapping,
-                                    flatten_reference_cube)
+from FIAT.reference_element import (make_affine_mapping,
+                                    flatten_reference_cube,
+                                    cell_to_simplex)
 from FIAT.P0 import P0Dual
 import numpy as np
-
-hypercube_simplex_map = {Point(): Point(),
-                         DefaultLine(): DefaultLine(),
-                         UFCInterval(): UFCInterval(),
-                         UFCQuadrilateral(): UFCTriangle(),
-                         UFCHexahedron(): UFCTetrahedron()}
 
 
 class DPC0(finite_element.CiarletElement):
     def __init__(self, ref_el):
         flat_el = flatten_reference_cube(ref_el)
-        poly_set = polynomial_set.ONPolynomialSet(hypercube_simplex_map[flat_el], 0)
+        poly_set = polynomial_set.ONPolynomialSet(cell_to_simplex(flat_el), 0)
         dual = P0Dual(ref_el)
         # Implement entity_permutations when we handle that for HigherOrderDPC.
         # Currently, orientation_tuples in P0Dual(ref_el).entity_permutations
@@ -58,7 +46,7 @@ class DPCDualSet(dual_set.DualSet):
 
         # Change coordinates here.
         # Vertices of the simplex corresponding to the reference element.
-        v_simplex = hypercube_simplex_map[flat_el].get_vertices()
+        v_simplex = cell_to_simplex(flat_el).get_vertices()
         # Vertices of the reference element.
         v_hypercube = flat_el.get_vertices()
         # For the mapping, first two vertices are unchanged in all dimensions.
@@ -74,12 +62,12 @@ class DPCDualSet(dual_set.DualSet):
 
         # make nodes by getting points
         # need to do this dimension-by-dimension, facet-by-facet
-        top = hypercube_simplex_map[flat_el].get_topology()
+        top = cell_to_simplex(flat_el).get_topology()
 
         cur = 0
         for dim in sorted(top):
             for entity in sorted(top[dim]):
-                pts_cur = hypercube_simplex_map[flat_el].make_points(dim, entity, degree)
+                pts_cur = cell_to_simplex(flat_el).make_points(dim, entity, degree)
                 pts_cur = [tuple(np.matmul(A, np.array(x)) + b) for x in pts_cur]
                 nodes_cur = [functional.PointEvaluation(flat_el, x)
                              for x in pts_cur]
@@ -102,7 +90,7 @@ class HigherOrderDPC(finite_element.CiarletElement):
 
     def __init__(self, ref_el, degree):
         flat_el = flatten_reference_cube(ref_el)
-        poly_set = polynomial_set.ONPolynomialSet(hypercube_simplex_map[flat_el], degree)
+        poly_set = polynomial_set.ONPolynomialSet(cell_to_simplex(flat_el), degree)
         dual = DPCDualSet(ref_el, flat_el, degree)
         formdegree = flat_el.get_spatial_dimension()  # n-form
         super().__init__(poly_set=poly_set,

--- a/FIAT/orientation_utils.py
+++ b/FIAT/orientation_utils.py
@@ -97,7 +97,7 @@ def _make_axis_perms_tensorproduct(cells, dim):
     This is the single sources of extrinsic orientations and corresponding axis permutations.
 
     """
-    from FIAT.reference_element import UFCInterval
+    from FIAT.reference_element import LINE
 
     # Handle extrinsic orientations.
     # This is complex and we need to think to make this function more general.
@@ -116,8 +116,8 @@ def _make_axis_perms_tensorproduct(cells, dim):
         #          dim == (2, 1) ->
         #          triangle x interval (1 possible extrinsic orientation).
         axis_perms = (tuple(range(nprod)), )  # Identity: no permutations
-    elif len(set(cells)) == 1 and isinstance(cells[0], UFCInterval):
-        # Tensor product of intervals.
+    elif len(set(cells)) == 1 and cells[0].get_shape() == LINE:
+        # Tensor product of intervals (any 1D reference cell implementation)
         # Example: interval x interval x interval x interval
         #          dim == (0, 1, 1, 1) ->
         #          point x interval x interval x interval  (1! * 3! possible extrinsic orientations).

--- a/FIAT/reference_element.py
+++ b/FIAT/reference_element.py
@@ -152,35 +152,18 @@ class Cell:
             # Given the topology, work out for each entity in the cell,
             # which other entities it contains.
             self.sub_entities = {}
-            self.sub_entities_old = {}
             for dim, entities in topology.items():
                 self.sub_entities[dim] = {}
-                self.sub_entities_old[dim] = {}
 
                 for e, v in entities.items():
                     vertices = frozenset(v)
                     sub_entities = []
-                    sub_entities_old = []
                     for dim_, entities_ in topology.items():
                         for e_, vertices_ in entities_.items():
                             if vertices.issuperset(vertices_):
-                                sub_entities_old.append((dim_, e_))
+                                sub_entities.append((dim_, e_))
 
-                        # in order to maintain ordering, extract subentities from vertex numbering
-                        entities_of_dim_ = list(entities_.values())
-
-                        from itertools import permutations
-                        # generate all possible sub entities
-                        sub_list = permutations(v, len(entities_of_dim_[0]))
-                        for s in sub_list:
-                            # add the sub entities in the same order as in topology
-                            for i, val in entities_.items():
-                                if set(s) == set(val) and (dim_, i) not in sub_entities:
-                                    sub_entities.append((dim_, i))
-
-                    self.sub_entities[dim][e] = list(sub_entities)
-                    self.sub_entities_old[dim][e] = list(sub_entities_old)
-                self.sub_entities = self.sub_entities_old
+                    self.sub_entities[dim][e] = sorted(list(sub_entities))
         # Build super-entity dictionary by inverting the sub-entity dictionary
         self.super_entities = {dim: {entity: [] for entity in topology[dim]} for dim in topology}
         for dim0 in topology:

--- a/finat/__init__.py
+++ b/finat/__init__.py
@@ -8,7 +8,8 @@ from .fiat_elements import (Bernstein, Bubble, BrezziDouglasFortinMarini,       
                             Lagrange, Real, Serendipity,                                     # noqa: F401
                             TrimmedSerendipityCurl, TrimmedSerendipityDiv,                   # noqa: F401
                             TrimmedSerendipityEdge, TrimmedSerendipityFace,                  # noqa: F401
-                            Nedelec, NedelecSecondKind, RaviartThomas, Regge)                # noqa: F401
+                            Nedelec, NedelecSecondKind, RaviartThomas, Regge,                # noqa: F401
+                            FuseElement)                                                     # noqa: F401
 from .spectral import (GaussLobattoLegendre, GaussLegendre, KongMulderVeldhuizen,            # noqa: F401
                        Legendre, IntegratedLegendre,                                         # noqa: F401
                        FDMLagrange, FDMQuadrature, FDMDiscontinuousLagrange,                 # noqa: F401

--- a/finat/element_factory.py
+++ b/finat/element_factory.py
@@ -24,6 +24,7 @@ from functools import singledispatch, cache
 
 import finat
 import finat.ufl
+import finat.zany
 import ufl
 
 from FIAT import ufc_cell
@@ -344,8 +345,8 @@ def convert_fuse_element(element, **kwargs):
             new_elem = new_elem.base_element
         finat_elem, deps = _create_element(new_elem.to_ufl(), **kwargs)
         return finat.FlattenedDimensions(finat_elem), deps
-    if finat.fiat_elements.is_scalar_zany(element.triple.to_fiat()):
-        return finat.fiat_elements.ScalarZanyFuseElement(element.triple), set()
+    if finat.zany.is_scalar_zany(element.triple.to_fiat()):
+        return finat.zany.ScalarZanyFuseElement(element.triple), set()
     return finat.fiat_elements.FuseElement(element.triple), set()
 
 

--- a/finat/element_factory.py
+++ b/finat/element_factory.py
@@ -109,15 +109,24 @@ FInAT-equivalent constructors.  If the value is ``None``, the UFL
 element is supported, but must be handled specially because it doesn't
 have a direct FInAT equivalent."""
 
+hexahedron_tpc = ufl.TensorProductCell(ufl.interval, ufl.interval, ufl.interval)
+quadrilateral_tpc = ufl.TensorProductCell(ufl.interval, ufl.interval)
+
 
 @cache
 def as_fiat_cell(cell):
     """Convert a ufl cell to a FIAT cell.
 
     :arg cell: the :class:`ufl.Cell` to convert."""
+    if isinstance(cell, str):
+        cell = finat.ufl.as_cell(cell)
     if not isinstance(cell, ufl.AbstractCell):
         raise ValueError("Expecting a UFL Cell")
-    return ufc_cell(cell)
+
+    if hasattr(cell, "to_fiat"):
+        return cell.to_fiat()
+    else:
+        return ufc_cell(cell)
 
 
 @singledispatch
@@ -325,12 +334,15 @@ def convert_restrictedelement(element, **kwargs):
     return finat.RestrictedElement(finat_elem, element.restriction_domain()), deps
 
 
-hexahedron_tpc = ufl.TensorProductCell(ufl.interval, ufl.interval, ufl.interval)
-quadrilateral_tpc = ufl.TensorProductCell(ufl.interval, ufl.interval)
+@convert.register(finat.ufl.FuseElement)
+def convert_fuse_element(element, **kwargs):
+    return finat.fiat_elements.FuseElement(element.triple), set()
+
+
 _cache = weakref.WeakKeyDictionary()
 
 
-def create_element(ufl_element, shape_innermost=True, shift_axes=0, restriction=None):
+def create_element(ufl_element, shape_innermost=True, shift_axes=0, restriction=None, use_fuse=False):
     """Create a FInAT element (suitable for tabulating with) given a UFL element.
 
     :arg ufl_element: The UFL element to create a FInAT element from.
@@ -341,7 +353,8 @@ def create_element(ufl_element, shape_innermost=True, shift_axes=0, restriction=
     finat_element, deps = _create_element(ufl_element,
                                           shape_innermost=shape_innermost,
                                           shift_axes=shift_axes,
-                                          restriction=restriction)
+                                          restriction=restriction,
+                                          use_fuse=use_fuse)
     return finat_element
 
 

--- a/finat/element_factory.py
+++ b/finat/element_factory.py
@@ -336,6 +336,16 @@ def convert_restrictedelement(element, **kwargs):
 
 @convert.register(finat.ufl.FuseElement)
 def convert_fuse_element(element, **kwargs):
+    if element.triple.flat:
+        new_elem = element.triple.unflatten()
+        if hasattr(new_elem, "base_element"):
+            # If element is wrapped, exclude the wrapping from this creation
+            # it is handled elsewhere in the converter.
+            new_elem = new_elem.base_element
+        finat_elem, deps = _create_element(new_elem.to_ufl(), **kwargs)
+        return finat.FlattenedDimensions(finat_elem), deps
+    if finat.fiat_elements.is_scalar_zany(element.triple.to_fiat()):
+        return finat.fiat_elements.ScalarZanyFuseElement(element.triple), set()
     return finat.fiat_elements.FuseElement(element.triple), set()
 
 

--- a/finat/fiat_elements.py
+++ b/finat/fiat_elements.py
@@ -439,3 +439,8 @@ class Nedelec(VectorFiatElement):
 class NedelecSecondKind(VectorFiatElement):
     def __init__(self, cell, degree, **kwargs):
         super().__init__(FIAT.NedelecSecondKind(cell, degree, **kwargs))
+
+
+class FuseElement(FiatElement):
+    def __init__(self, triple):
+        super(FuseElement, self).__init__(triple.to_fiat())

--- a/finat/fiat_elements.py
+++ b/finat/fiat_elements.py
@@ -5,6 +5,7 @@ from gem.utils import cached_property
 
 from finat.finiteelementbase import FiniteElementBase
 from finat.point_set import PointSet, PointSingleton
+from finat.zany import ScalarPhysicallyMappedElement
 
 
 class FiatElement(FiniteElementBase):
@@ -444,3 +445,27 @@ class NedelecSecondKind(VectorFiatElement):
 class FuseElement(FiatElement):
     def __init__(self, triple):
         super(FuseElement, self).__init__(triple.to_fiat())
+
+
+class ScalarZanyFuseElement(ScalarPhysicallyMappedElement, FuseElement):
+    """A FUSE element whose dofs involve derivatives.
+
+    Such an element is not affinely equivalent, so its reference basis must
+    be transformed on each physical cell. The transformation is derived
+    generically from the dual basis by
+    :meth:`~finat.physically_mapped.PhysicallyMappedElement.basis_transformation`.
+    """
+
+
+def is_scalar_zany(fiat_element):
+    """Whether a FUSE-generated FIAT element needs an affine zany transformation.
+
+    True for affinely pulled back elements carrying at least one derivative
+    dof. Elements whose dofs are all point values or moments (Lagrange,
+    Raviart-Thomas, Nedelec) are affinely equivalent and need no transformation.
+
+    :arg fiat_element: The FIAT element defined on the reference cell.
+    """
+    if set(fiat_element.mapping()) != {"affine"}:
+        return False
+    return any(node.max_deriv_order > 0 for node in fiat_element.dual_basis())

--- a/finat/fiat_elements.py
+++ b/finat/fiat_elements.py
@@ -4,9 +4,7 @@ import numpy as np
 from gem.utils import cached_property
 
 from finat.finiteelementbase import FiniteElementBase
-from finat.functional import PhysicallyMappedFunctional, multiindices
 from finat.point_set import PointSet, PointSingleton
-from finat.zany import ScalarPhysicallyMappedElement
 
 
 class FiatElement(FiniteElementBase):
@@ -447,84 +445,3 @@ class FuseElement(FiatElement):
     def __init__(self, triple):
         self.triple = triple
         super(FuseElement, self).__init__(triple.to_fiat())
-
-
-class ScalarZanyFuseElement(ScalarPhysicallyMappedElement, FuseElement):
-    """A FUSE element whose dofs involve derivatives.
-
-    Such an element is not affinely equivalent, so its reference basis must
-    be transformed on each physical cell. The transformation is derived
-    generically from the dual basis by
-    :meth:`~finat.physically_mapped.PhysicallyMappedElement.basis_transformation`.
-    """
-
-    @cached_property
-    def _fuse_dofs(self):
-        """Map from dual basis index to the FUSE dof it was built from."""
-        return {self.triple.dof_id_to_fiat_id[dof.id]: dof
-                for dof in self.triple.generate()}
-
-    def _functional_from_node(self, node, index, mapping):
-        """Take the derivative direction from the FUSE trace that defines it.
-
-        FUSE states the direction of a derivative dof symbolically, so it can
-        be used as it stands instead of being recovered from the derivative
-        weights by the factorization in
-        :meth:`~finat.functional.PhysicallyMappedFunctional.from_fiat`.
-        """
-        direction = self._fuse_direction(node, index)
-        if direction is None:
-            return super()._functional_from_node(node, index, mapping)
-
-        sd = node.ref_el.get_spatial_dimension()
-        order = node.max_deriv_order
-        alphas = multiindices(sd, order)
-        lookup = {alpha: k for k, alpha in enumerate(alphas)}
-        points = tuple(node.deriv_dict)
-        weights = np.zeros((len(points), len(alphas)))
-        for q, pt in enumerate(points):
-            for w, alpha, comp in node.deriv_dict[pt]:
-                weights[q, lookup[tuple(alpha)]] += w
-
-        # the weights are the direction scaled point by point
-        scale = weights @ direction / (direction @ direction)
-        if not np.allclose(np.outer(scale, direction), weights):
-            return super()._functional_from_node(node, index, mapping)
-        return PhysicallyMappedFunctional(points, scale, order=order,
-                                          direction=direction, mapping=mapping)
-
-    def _fuse_direction(self, node, index):
-        """The exact derivative direction of a dof, or None if it has none."""
-        if not node.deriv_dict or node.get_point_dict():
-            return None
-        dof = self._fuse_dofs.get(index)
-        if dof is None or dof.target_space is None:
-            return None
-        terms = dof.target_space.tabulate_derivs(None, dof.cell_defined_on)
-        if not terms:
-            return None
-        sd = node.ref_el.get_spatial_dimension()
-        alphas = multiindices(sd, node.max_deriv_order)
-        lookup = {alpha: k for k, alpha in enumerate(alphas)}
-        direction = np.zeros(len(alphas))
-        for coeff, alpha in terms:
-            if tuple(alpha) not in lookup:
-                return None
-            direction[lookup[tuple(alpha)]] += coeff
-        if not direction.any():
-            return None
-        return direction
-
-
-def is_scalar_zany(fiat_element):
-    """Whether a FUSE-generated FIAT element needs an affine zany transformation.
-
-    True for affinely pulled back elements carrying at least one derivative
-    dof. Elements whose dofs are all point values or moments (Lagrange,
-    Raviart-Thomas, Nedelec) are affinely equivalent and need no transformation.
-
-    :arg fiat_element: The FIAT element defined on the reference cell.
-    """
-    if set(fiat_element.mapping()) != {"affine"}:
-        return False
-    return any(node.max_deriv_order > 0 for node in fiat_element.dual_basis())

--- a/finat/fiat_elements.py
+++ b/finat/fiat_elements.py
@@ -4,6 +4,7 @@ import numpy as np
 from gem.utils import cached_property
 
 from finat.finiteelementbase import FiniteElementBase
+from finat.functional import PhysicallyMappedFunctional, multiindices
 from finat.point_set import PointSet, PointSingleton
 from finat.zany import ScalarPhysicallyMappedElement
 
@@ -444,6 +445,7 @@ class NedelecSecondKind(VectorFiatElement):
 
 class FuseElement(FiatElement):
     def __init__(self, triple):
+        self.triple = triple
         super(FuseElement, self).__init__(triple.to_fiat())
 
 
@@ -455,6 +457,63 @@ class ScalarZanyFuseElement(ScalarPhysicallyMappedElement, FuseElement):
     generically from the dual basis by
     :meth:`~finat.physically_mapped.PhysicallyMappedElement.basis_transformation`.
     """
+
+    @cached_property
+    def _fuse_dofs(self):
+        """Map from dual basis index to the FUSE dof it was built from."""
+        return {self.triple.dof_id_to_fiat_id[dof.id]: dof
+                for dof in self.triple.generate()}
+
+    def _functional_from_node(self, node, index, mapping):
+        """Take the derivative direction from the FUSE trace that defines it.
+
+        FUSE states the direction of a derivative dof symbolically, so it can
+        be used as it stands instead of being recovered from the derivative
+        weights by the factorization in
+        :meth:`~finat.functional.PhysicallyMappedFunctional.from_fiat`.
+        """
+        direction = self._fuse_direction(node, index)
+        if direction is None:
+            return super()._functional_from_node(node, index, mapping)
+
+        sd = node.ref_el.get_spatial_dimension()
+        order = node.max_deriv_order
+        alphas = multiindices(sd, order)
+        lookup = {alpha: k for k, alpha in enumerate(alphas)}
+        points = tuple(node.deriv_dict)
+        weights = np.zeros((len(points), len(alphas)))
+        for q, pt in enumerate(points):
+            for w, alpha, comp in node.deriv_dict[pt]:
+                weights[q, lookup[tuple(alpha)]] += w
+
+        # the weights are the direction scaled point by point
+        scale = weights @ direction / (direction @ direction)
+        if not np.allclose(np.outer(scale, direction), weights):
+            return super()._functional_from_node(node, index, mapping)
+        return PhysicallyMappedFunctional(points, scale, order=order,
+                                          direction=direction, mapping=mapping)
+
+    def _fuse_direction(self, node, index):
+        """The exact derivative direction of a dof, or None if it has none."""
+        if not node.deriv_dict or node.get_point_dict():
+            return None
+        dof = self._fuse_dofs.get(index)
+        if dof is None or dof.target_space is None:
+            return None
+        terms = dof.target_space.tabulate_derivs(None, dof.cell_defined_on)
+        if not terms:
+            return None
+        sd = node.ref_el.get_spatial_dimension()
+        alphas = multiindices(sd, node.max_deriv_order)
+        lookup = {alpha: k for k, alpha in enumerate(alphas)}
+        direction = np.zeros(len(alphas))
+        for coeff, alpha in terms:
+            if tuple(alpha) not in lookup:
+                return None
+            direction[lookup[tuple(alpha)]] += coeff
+        if not direction.any():
+            return None
+        return direction
 
 
 def is_scalar_zany(fiat_element):

--- a/finat/physically_mapped.py
+++ b/finat/physically_mapped.py
@@ -203,8 +203,8 @@ class PhysicallyMappedElement(NeedsCoordinateMappingElement):
                         continue
                     owners[i] = (dim, entity)
                     try:
-                        ells[i] = PhysicallyMappedFunctional.from_fiat(
-                            nodes[i], mapping=mappings[i])
+                        ells[i] = self._functional_from_node(
+                            nodes[i], i, mappings[i])
                     except NotImplementedError:
                         if i < ndof:
                             raise
@@ -281,6 +281,22 @@ class PhysicallyMappedElement(NeedsCoordinateMappingElement):
                 row, den = res
                 B[i] = row / den
         return B
+
+    def _functional_from_node(self, node, index: int, mapping: str):
+        """Build the symbolic functional of one dof of the dual basis.
+
+        By default the point locations, derivative order and direction are
+        recovered numerically from the FIAT functional. Elements whose dofs
+        are known symbolically may override this to supply them exactly.
+
+        :arg node: The FIAT functional of the dof.
+        :arg index: Its index in the dual basis.
+        :arg mapping: The FIAT mapping string of the basis functions this
+            functional is dual to.
+        :returns: The corresponding
+            :class:`~finat.functional.PhysicallyMappedFunctional`.
+        """
+        return PhysicallyMappedFunctional.from_fiat(node, mapping=mapping)
 
     def _check_mapping(self, fiat_element: FiniteElement) -> None:
         """Verify that this class knows how to transform this element's pullback.

--- a/finat/ufl/__init__.py
+++ b/finat/ufl/__init__.py
@@ -14,8 +14,9 @@
 from finat.ufl.brokenelement import BrokenElement  # noqa: F401
 from finat.ufl.enrichedelement import EnrichedElement, NodalEnrichedElement  # noqa: F401
 from finat.ufl.finiteelement import FiniteElement  # noqa: F401
-from finat.ufl.finiteelementbase import FiniteElementBase  # noqa: F401
+from finat.ufl.finiteelementbase import FiniteElementBase, as_cell  # noqa: F401
 from finat.ufl.hdivcurl import HCurlElement, HDivElement, WithMapping, HDiv, HCurl  # noqa: F401
 from finat.ufl.mixedelement import MixedElement, TensorElement, VectorElement  # noqa: F401
 from finat.ufl.restrictedelement import RestrictedElement  # noqa: F401
 from finat.ufl.tensorproductelement import TensorProductElement  # noqa: F401
+from finat.ufl.fuseelement import FuseElement  # noqa: F401

--- a/finat/ufl/elementlist.py
+++ b/finat/ufl/elementlist.py
@@ -418,6 +418,8 @@ def canonical_element_description(family, cell, order, form_degree):
 
     # Check that the element family exists
     if family not in ufl_elements:
+        if repr(family).startswith("FuseTriple"):
+            raise ValueError("Recieved unconverted FUSE triple - did you forget to call to_ufl()?")
         raise ValueError(f"Unknown finite element '{family}'.")
 
     # Check that element data is valid (and also get common family

--- a/finat/ufl/finiteelement.py
+++ b/finat/ufl/finiteelement.py
@@ -11,9 +11,9 @@
 # Modified by Massimiliano Leoni, 2016
 # Modified by Matthew Scroggs, 2023
 
-from ufl.cell import TensorProductCell, as_cell
+from ufl.cell import TensorProductCell
 from finat.ufl.elementlist import canonical_element_description, simplices
-from finat.ufl.finiteelementbase import FiniteElementBase
+from finat.ufl.finiteelementbase import FiniteElementBase, as_cell
 from ufl.utils.formatting import istr
 
 

--- a/finat/ufl/finiteelementbase.py
+++ b/finat/ufl/finiteelementbase.py
@@ -15,7 +15,7 @@ from abc import abstractmethod, abstractproperty
 from hashlib import md5
 
 from ufl import pullback
-from ufl.cell import AbstractCell, as_cell
+from ufl.cell import AbstractCell, as_cell as as_cell_ufl
 from ufl.finiteelement import AbstractFiniteElement
 from ufl.utils.sequences import product
 
@@ -272,3 +272,14 @@ class FiniteElementBase(AbstractFiniteElement):
             return supported_pullbacks[self.mapping()]
         except KeyError:
             raise ValueError(f"Unsupported mapping: {self.mapping()}")
+
+
+def as_cell(cell: AbstractCell | str | tuple[AbstractCell, ...], use_fuse: bool = False) -> AbstractCell:
+    if isinstance(cell, str) and use_fuse:
+        try:
+            import fuse
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError("Cannot create FUSE cell without FUSE")
+        return fuse.constructCellComplex(cell)
+    else:
+        return as_cell_ufl(cell)

--- a/finat/ufl/fuseelement.py
+++ b/finat/ufl/fuseelement.py
@@ -1,0 +1,44 @@
+"""Element."""
+# -*- coding: utf-8 -*-
+# Copyright (C) 2025 India Marsden
+#
+# SPDX-License-Identifier:    LGPL-3.0-or-later
+
+from finat.ufl.finiteelementbase import FiniteElementBase
+
+
+class FuseElement(FiniteElementBase):
+    """
+    A finite element defined using FUSE.
+
+    TODO: Need to deal with cases where value shape and reference value shape are different
+    """
+
+    def __init__(self, triple, cell=None):
+        self.triple = triple
+        if not cell:
+            cell = self.triple.cell.to_ufl()
+
+        degree = self.triple.degree
+        self.sobolev_space = self.triple.spaces[1].to_ufl()
+        super(FuseElement, self).__init__("IT", cell, degree, None, triple.get_value_shape())
+
+    def __repr__(self):
+        return repr(self.triple)
+
+    def __str__(self):
+        return "<Fuse%sElem on %s>" % (self.triple.spaces[0], self.triple.cell)
+
+    def mapping(self):
+        if str(self.sobolev_space) == "HCurl":
+            return "covariant Piola"
+        elif str(self.sobolev_space) == "HDiv":
+            return "contravariant Piola"
+        else:
+            return "identity"
+
+    def sobolev_space(self):
+        return self.triple.spaces[1]
+
+    def reconstruct(self, family=None, cell=None, degree=None, quad_scheme=None, variant=None):
+        return FuseElement(self.triple, cell=cell)

--- a/finat/ufl/mixedelement.py
+++ b/finat/ufl/mixedelement.py
@@ -13,10 +13,10 @@
 
 import numpy as np
 
-from ufl.cell import CellSequence, as_cell
+from ufl.cell import CellSequence
 from ufl.domain import MeshSequence
 from finat.ufl.finiteelement import FiniteElement
-from finat.ufl.finiteelementbase import FiniteElementBase
+from finat.ufl.finiteelementbase import FiniteElementBase, as_cell
 from ufl.permutation import compute_indices
 from ufl.pullback import MixedPullback, SymmetricPullback
 from ufl.utils.indexflattening import flatten_multiindex, shape_to_strides, unflatten_index

--- a/finat/ufl/tensorproductelement.py
+++ b/finat/ufl/tensorproductelement.py
@@ -13,8 +13,9 @@
 
 from itertools import chain
 
-from ufl.cell import TensorProductCell, as_cell
-from finat.ufl.finiteelementbase import FiniteElementBase
+from ufl.cell import TensorProductCell
+from finat.ufl.finiteelementbase import FiniteElementBase, as_cell
+
 from ufl.sobolevspace import DirectionalSobolevSpace
 
 

--- a/finat/zany.py
+++ b/finat/zany.py
@@ -25,8 +25,13 @@ pattern.  The classes here only carry the family-specific conventions:
   and Hu-Zhang conventions.
 """
 
-from FIAT.finite_element import FiniteElement
+import numpy as np
 
+from FIAT.finite_element import FiniteElement
+from gem.utils import cached_property
+
+from finat.fiat_elements import FuseElement
+from finat.functional import PhysicallyMappedFunctional, multiindices
 from finat.physically_mapped import PhysicallyMappedElement
 
 
@@ -81,3 +86,84 @@ class PiolaPhysicallyMappedElement(PhysicallyMappedElement):
             if len(max(comps)) == 2:
                 return havg**(-2)
         return super().dof_scale(node, dim, havg)
+
+
+class ScalarZanyFuseElement(ScalarPhysicallyMappedElement, FuseElement):
+    """A FUSE element whose dofs involve derivatives.
+
+    Such an element is not affinely equivalent, so its reference basis must
+    be transformed on each physical cell. The transformation is derived
+    generically from the dual basis by
+    :meth:`~finat.physically_mapped.PhysicallyMappedElement.basis_transformation`.
+    """
+
+    @cached_property
+    def _fuse_dofs(self):
+        """Map from dual basis index to the FUSE dof it was built from."""
+        return {self.triple.dof_id_to_fiat_id[dof.id]: dof
+                for dof in self.triple.generate()}
+
+    def _functional_from_node(self, node, index, mapping):
+        """Take the derivative direction from the FUSE trace that defines it.
+
+        FUSE states the direction of a derivative dof symbolically, so it can
+        be used as it stands instead of being recovered from the derivative
+        weights by the factorization in
+        :meth:`~finat.functional.PhysicallyMappedFunctional.from_fiat`.
+        """
+        direction = self._fuse_direction(node, index)
+        if direction is None:
+            return super()._functional_from_node(node, index, mapping)
+
+        sd = node.ref_el.get_spatial_dimension()
+        order = node.max_deriv_order
+        alphas = multiindices(sd, order)
+        lookup = {alpha: k for k, alpha in enumerate(alphas)}
+        points = tuple(node.deriv_dict)
+        weights = np.zeros((len(points), len(alphas)))
+        for q, pt in enumerate(points):
+            for w, alpha, comp in node.deriv_dict[pt]:
+                weights[q, lookup[tuple(alpha)]] += w
+
+        # the weights are the direction scaled point by point
+        scale = weights @ direction / (direction @ direction)
+        if not np.allclose(np.outer(scale, direction), weights):
+            return super()._functional_from_node(node, index, mapping)
+        return PhysicallyMappedFunctional(points, scale, order=order,
+                                          direction=direction, mapping=mapping)
+
+    def _fuse_direction(self, node, index):
+        """The exact derivative direction of a dof, or None if it has none."""
+        if not node.deriv_dict or node.get_point_dict():
+            return None
+        dof = self._fuse_dofs.get(index)
+        if dof is None or dof.target_space is None:
+            return None
+        terms = dof.target_space.tabulate_derivs(None, dof.cell_defined_on)
+        if not terms:
+            return None
+        sd = node.ref_el.get_spatial_dimension()
+        alphas = multiindices(sd, node.max_deriv_order)
+        lookup = {alpha: k for k, alpha in enumerate(alphas)}
+        direction = np.zeros(len(alphas))
+        for coeff, alpha in terms:
+            if tuple(alpha) not in lookup:
+                return None
+            direction[lookup[tuple(alpha)]] += coeff
+        if not direction.any():
+            return None
+        return direction
+
+
+def is_scalar_zany(fiat_element):
+    """Whether a FUSE-generated FIAT element needs an affine zany transformation.
+
+    True for affinely pulled back elements carrying at least one derivative
+    dof. Elements whose dofs are all point values or moments (Lagrange,
+    Raviart-Thomas, Nedelec) are affinely equivalent and need no transformation.
+
+    :arg fiat_element: The FIAT element defined on the reference cell.
+    """
+    if set(fiat_element.mapping()) != {"affine"}:
+        return False
+    return any(node.max_deriv_order > 0 for node in fiat_element.dual_basis())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
   "scipy",
   "symengine",
   "sympy",
+  "fuse-element @ git+https://github.com/firedrakeproject/fuse.git",
 ]
 requires-python = ">=3.11"
 authors = [


### PR DESCRIPTION
Changes that use the FUSE symbolic directions directly to construct the zany mappings, avoiding the SVD. 

Includes general FUSE changes (indiamai/fuse, PR #265 ) and works in conjunction with the FUSE PR to add derivatives [FUSE PR #17](https://github.com/firedrakeproject/fuse/pull/17)
Primary zany change:
- Add hook `_functional_from_node` that resolves numerically (unchanged) for non-fuse elements, and builds the dictionaries directly from FUSE symbolics for FUSE elements. 

Currently limited to the non Piola type Zany elements. 