### PR TITLE
Add the prose rules to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,8 +128,9 @@ def scale_boundary_nodes(u, factor):
 
 ### Documenting Code That Is Not There
 
-A reader has only the file in front of them. A comment that describes a removed approach, or that
-argues against a branch the code does not take, sends them looking for something that is not there.
+A reader has only the file in front of them. A comment can describe a removed approach. It can also
+argue against a branch the code does not take. Either one sends the reader looking for something
+that is not there.
 
 WRONG — the first sentence describes deleted code, and the second argues with an absent branch:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,3 +97,59 @@ When writing Python code for FIAT, maintain the ecosystem's structural and styli
 * CI enforces `pydocstyle` (see the `[pydocstyle]` section of `setup.cfg` for the active ignore list)
   in addition to `flake8`; run `pydocstyle <changed files>` locally before finishing a change, since a
   clean `flake8` pass does not imply a clean `pydocstyle` pass.
+* Every docstring or comment you write or touch must follow Simplified Technical English
+  (ASD-STE100): short sentences, one idea per sentence, active voice, subject named up front instead
+  of buried in a relative clause. Avoid the clause-stacking, inverted phrasing typical of unedited
+  AI-generated prose.
+* When fixing code that was wrong, do not leave comments or prose explaining what the removed,
+  incorrect approach used to do or why it was wrong. Keep comments and documentation focused on the
+  current, correct code. The test to apply: a reader who never saw the diff must not be able to tell
+  that anything was removed.
+
+## Anti-Patterns
+
+These must be avoided when writing code, and flagged when reviewing it.
+
+### Clause-Stacked Docstrings And Comments
+
+WRONG — the subject hides inside a relative clause the reader must unwind before finding the verb:
+
+```python
+def scale_boundary_nodes(u, factor):
+    """Give the nodes a boundary condition constrains their scaled values."""
+```
+
+RIGHT — subject named up front, one short sentence, active voice:
+
+```python
+def scale_boundary_nodes(u, factor):
+    """Scale the values of the nodes that a boundary condition constrains."""
+```
+
+### Documenting Code That Is Not There
+
+A reader has only the file in front of them. A comment that describes a removed approach, or that
+argues against a branch the code does not take, sends them looking for something that is not there.
+
+WRONG — the first sentence describes deleted code, and the second argues with an absent branch:
+
+```python
+def barycentric_weights(points):
+    # This no longer normalises the weights, which was wrong when the points
+    # were not symmetric. A test for a repeated point here would divide by
+    # zero.
+    return 1.0 / numpy.prod(points[:, None] - points[None, :] + numpy.eye(len(points)), axis=1)
+```
+
+RIGHT — say what the present code does, and state the condition it relies on:
+
+```python
+def barycentric_weights(points):
+    # The identity keeps the diagonal out of the product. The caller passes
+    # distinct points.
+    return 1.0 / numpy.prod(points[:, None] - points[None, :] + numpy.eye(len(points)), axis=1)
+```
+
+Some words give this away on sight: "used to", "previously", "no longer", "instead of", "we removed",
+"this replaces". Watch equally for "would" when its subject is code that does not exist. An argument
+against a branch that nobody can see is still a description of the past.


### PR DESCRIPTION
# Description
AI-assisted (Claude Code)

`AGENTS.md` only, no code. Companion to firedrakeproject/firedrake#5338, which makes the same two
additions on the Firedrake side.

FIAT's Style and Conventions section already matches Firedrake's on class attributes, the `hasattr`
prohibition, type hints and numpydoc. It carries neither prose rule, so agent-written prose here is
unconstrained.

## Main changes

- **Plain English (ASD-STE100)** for docstrings and comments, with a *Clause-Stacked Docstrings And
  Comments* anti-pattern. Unedited AI prose reliably produces garden-path sentences that bury the
  subject in a relative clause.
- **Documenting Code That Is Not There.** The case worth naming is not "this used to do X", which
  nobody writes, but an argument against a branch that was just removed:

  ```python
  # A test for a repeated point here would divide by zero.
  ```

  That reads as present tense while describing absent code. The rule carries a test a reader can
  apply — *a reader who never saw the diff must not be able to tell that anything was removed* — and
  the words that give it away, including `would` when its subject does not exist.

This adds the first `## Anti-Patterns` section to FIAT's `AGENTS.md`. Both examples use small FIAT-
flavoured functions rather than real code, so they do not go stale.

## Why examples rather than prose

The rules with WRONG/RIGHT pairs get followed; the ones stated only as prose get missed. On the
Firedrake side, `Document The Present, Not The Past` was violated during the work that produced
firedrakeproject/firedrake#5337 while the rule was sitting in the file, and a human caught it rather
than the rule. These two are also mechanically checkable, and I am running a local `PostToolUse` hook
that greps added lines for the Sphinx field-list style, over-long sentences, the past-tense tells,
and the `hasattr` guard.