### PR TITLE
Keep factorised contractions atomic in dual evaluation

### DIFF
--- a/finat/finiteelementbase.py
+++ b/finat/finiteelementbase.py
@@ -279,7 +279,7 @@ class FiniteElementBase(metaclass=ABCMeta):
         Qi = Q[basis_indices + shape_indices]
         expri = expr[shape_indices]
         evaluation = gem.IndexSum(Qi * expri, x.indices + shape_indices)
-        # Factorise over the new contraction with x, keeping whole the
+        # Factorise over the new contraction with Qi, keeping whole the
         # contractions that fn already factorised
         evaluation = gem.optimise.contraction(evaluation, stop_at=is_contraction)
         return evaluation, basis_indices

--- a/finat/finiteelementbase.py
+++ b/finat/finiteelementbase.py
@@ -268,7 +268,6 @@ class FiniteElementBase(metaclass=ABCMeta):
         expr = fn(x)
         # Apply targeted sum factorisation and delta elimination to
         # the expression, preserving contractions that fn already factorised
-        # the expression, preserving contractions that fn already factorised
         # FIXME: a single pass of gem.optimise.contraction will choke on too many indices
         # This is a temporary workaround https://github.com/firedrakeproject/fiat/issues/283
         sum_indices, factors = delta_elimination(*traverse_product(expr, stop_at=is_contraction))

--- a/finat/finiteelementbase.py
+++ b/finat/finiteelementbase.py
@@ -268,6 +268,9 @@ class FiniteElementBase(metaclass=ABCMeta):
         expr = fn(x)
         # Apply targeted sum factorisation and delta elimination to
         # the expression, preserving contractions that fn already factorised
+        # the expression, preserving contractions that fn already factorised
+        # FIXME: a single pass of gem.optimise.contraction will choke on too many indices
+        # This is a temporary workaround https://github.com/firedrakeproject/fiat/issues/283
         sum_indices, factors = delta_elimination(*traverse_product(expr, stop_at=is_contraction))
         expr = sum_factorise(sum_indices, factors)
         # NOTE: any shape indices in the expression are because the

--- a/finat/finiteelementbase.py
+++ b/finat/finiteelementbase.py
@@ -4,7 +4,8 @@ from itertools import chain
 import gem
 import numpy
 from gem.interpreter import evaluate
-from gem.optimise import delta_elimination, sum_factorise, traverse_product
+from gem.optimise import (delta_elimination, is_contraction, sum_factorise,
+                          traverse_product)
 from gem.utils import cached_property
 
 from finat.quadrature import make_quadrature
@@ -266,8 +267,9 @@ class FiniteElementBase(metaclass=ABCMeta):
 
         expr = fn(x)
         # Apply targeted sum factorisation and delta elimination to
-        # the expression
-        sum_indices, factors = delta_elimination(*traverse_product(expr))
+        # the expression, preserving contractions that fn already
+        # factorised
+        sum_indices, factors = delta_elimination(*traverse_product(expr, stop_at=is_contraction))
         expr = sum_factorise(sum_indices, factors)
         # NOTE: any shape indices in the expression are because the
         # expression is tensor valued.
@@ -281,7 +283,8 @@ class FiniteElementBase(metaclass=ABCMeta):
         # ignoring any shape indices to avoid hitting the sum-
         # factorisation index limit (this is a bit of a hack).
         # Really need to do a more targeted job here.
-        evaluation = gem.optimise.contraction(evaluation, shape_indices)
+        evaluation = gem.optimise.contraction(evaluation, shape_indices,
+                                              stop_at=is_contraction)
         return evaluation, basis_indices
 
     def dual_transformation(self, Q, coordinate_mapping=None):

--- a/finat/finiteelementbase.py
+++ b/finat/finiteelementbase.py
@@ -279,12 +279,9 @@ class FiniteElementBase(metaclass=ABCMeta):
         Qi = Q[basis_indices + shape_indices]
         expri = expr[shape_indices]
         evaluation = gem.IndexSum(Qi * expri, x.indices + shape_indices)
-        # Now we want to factorise over the new contraction with x,
-        # ignoring any shape indices to avoid hitting the sum-
-        # factorisation index limit (this is a bit of a hack).
-        # Really need to do a more targeted job here.
-        evaluation = gem.optimise.contraction(evaluation, shape_indices,
-                                              stop_at=is_contraction)
+        # Factorise over the new contraction with x, keeping whole the
+        # contractions that fn already factorised
+        evaluation = gem.optimise.contraction(evaluation, stop_at=is_contraction)
         return evaluation, basis_indices
 
     def dual_transformation(self, Q, coordinate_mapping=None):

--- a/finat/finiteelementbase.py
+++ b/finat/finiteelementbase.py
@@ -267,8 +267,7 @@ class FiniteElementBase(metaclass=ABCMeta):
 
         expr = fn(x)
         # Apply targeted sum factorisation and delta elimination to
-        # the expression, preserving contractions that fn already
-        # factorised
+        # the expression, preserving contractions that fn already factorised
         sum_indices, factors = delta_elimination(*traverse_product(expr, stop_at=is_contraction))
         expr = sum_factorise(sum_indices, factors)
         # NOTE: any shape indices in the expression are because the

--- a/finat/tensorfiniteelement.py
+++ b/finat/tensorfiniteelement.py
@@ -179,6 +179,8 @@ class TensorFiniteElement(FiniteElementBase):
         expr = fn(x)
         # Apply targeted sum factorisation and delta elimination to
         # the expression, preserving contractions that fn already factorised
+        # FIXME: a single pass of gem.optimise.contraction will choke on too many indices
+        # This is a temporary workaround https://github.com/firedrakeproject/fiat/issues/283
         sum_indices, factors = delta_elimination(*traverse_product(expr, stop_at=is_contraction))
         expr = sum_factorise(sum_indices, factors)
         # NOTE: any shape indices in the expression are because the

--- a/finat/tensorfiniteelement.py
+++ b/finat/tensorfiniteelement.py
@@ -3,7 +3,8 @@ from itertools import chain
 import numpy
 
 import gem
-from gem.optimise import delta_elimination, sum_factorise, traverse_product
+from gem.optimise import (delta_elimination, is_contraction, sum_factorise,
+                          traverse_product)
 from gem.utils import cached_property
 
 from finat.finiteelementbase import FiniteElementBase
@@ -177,8 +178,9 @@ class TensorFiniteElement(FiniteElementBase):
 
         expr = fn(x)
         # Apply targeted sum factorisation and delta elimination to
-        # the expression
-        sum_indices, factors = delta_elimination(*traverse_product(expr))
+        # the expression, preserving contractions that fn already
+        # factorised
+        sum_indices, factors = delta_elimination(*traverse_product(expr, stop_at=is_contraction))
         expr = sum_factorise(sum_indices, factors)
         # NOTE: any shape indices in the expression are because the
         # expression is tensor valued.
@@ -200,7 +202,7 @@ class TensorFiniteElement(FiniteElementBase):
         # This doesn't work perfectly, the resulting code doesn't have
         # a minimal memory footprint, although the operation count
         # does appear to be minimal.
-        evaluation = gem.optimise.contraction(evaluation)
+        evaluation = gem.optimise.contraction(evaluation, stop_at=is_contraction)
         return evaluation, scalar_i + tensor_vi
 
     @property

--- a/finat/tensorfiniteelement.py
+++ b/finat/tensorfiniteelement.py
@@ -178,8 +178,7 @@ class TensorFiniteElement(FiniteElementBase):
 
         expr = fn(x)
         # Apply targeted sum factorisation and delta elimination to
-        # the expression, preserving contractions that fn already
-        # factorised
+        # the expression, preserving contractions that fn already factorised
         sum_indices, factors = delta_elimination(*traverse_product(expr, stop_at=is_contraction))
         expr = sum_factorise(sum_indices, factors)
         # NOTE: any shape indices in the expression are because the

--- a/gem/optimise.py
+++ b/gem/optimise.py
@@ -654,17 +654,13 @@ def is_contraction(expression: Node) -> bool:
     return isinstance(expression, IndexSum)
 
 
-def contraction(expression, ignore=None, stop_at=None):
+def contraction(expression, stop_at=None):
     """Optimise the contractions of the tensor product at the root of
     the expression, including:
 
     - IndexSum-Delta cancellation
     - Sum factorisation
 
-    :arg ignore: Optional set of indices to ignore when applying sum
-        factorisation (otherwise all summation indices will be
-        considered). Use this if your expression has many contraction
-        indices.
     :arg stop_at: Optional predicate on GEM expressions that are not to
         be broken into further factors, see :func:`traverse_product`.
         The contraction at the root is always broken up, as that is the
@@ -688,15 +684,7 @@ def contraction(expression, ignore=None, stop_at=None):
             stop_at=None if stop_at is None else lambda e: e is not root and stop_at(e))
         sum_indices, factors = delta_elimination(sum_indices, factors, index_replacer=index_replacer)
         factors = [index_replacer(f, ()) for f in factors]
-        if ignore is not None:
-            # TODO: This is a really blunt instrument and one might
-            # plausibly want the ignored indices to be contracted on
-            # the inside rather than the outside.
-            extra = tuple(i for i in sum_indices if i in ignore)
-            to_factor = tuple(i for i in sum_indices if i not in ignore)
-            return IndexSum(sum_factorise(to_factor, factors), extra)
-        else:
-            return sum_factorise(sum_indices, factors)
+        return sum_factorise(sum_indices, factors)
 
     # Sometimes the value shape is composed as a ListTensor, which
     # could get in the way of decomposing factors.  In particular,

--- a/gem/optimise.py
+++ b/gem/optimise.py
@@ -630,7 +630,31 @@ def traverse_sum(expression, stop_at=None):
     return result
 
 
-def contraction(expression, ignore=None):
+def is_contraction(expression: Node) -> bool:
+    """Test whether an expression is a tensor contraction.
+
+    Parameters
+    ----------
+    expression :
+        A GEM expression.
+
+    Returns
+    -------
+    bool
+        Whether the expression is a contraction.
+
+    Notes
+    -----
+    Pass this as ``stop_at`` to keep a contraction that is already sum
+    factorised out of a surrounding one. Flattening it discards its
+    factorisation, along with any subexpression it shares with another
+    factor, and inflates the number of indices to factorise over.
+
+    """
+    return isinstance(expression, IndexSum)
+
+
+def contraction(expression, ignore=None, stop_at=None):
     """Optimise the contractions of the tensor product at the root of
     the expression, including:
 
@@ -641,6 +665,10 @@ def contraction(expression, ignore=None):
         factorisation (otherwise all summation indices will be
         considered). Use this if your expression has many contraction
         indices.
+    :arg stop_at: Optional predicate on GEM expressions that are not to
+        be broken into further factors, see :func:`traverse_product`.
+        The contraction at the root is always broken up, as that is the
+        one being optimised.
 
     This routine was designed with finite element coefficient
     evaluation in mind.
@@ -654,7 +682,10 @@ def contraction(expression, ignore=None):
 
     # Flatten product tree, eliminate deltas, sum factorise
     def rebuild(expression):
-        sum_indices, factors = traverse_product(expression, index_replacer=index_replacer)
+        root = expression
+        sum_indices, factors = traverse_product(
+            expression, index_replacer=index_replacer,
+            stop_at=None if stop_at is None else lambda e: e is not root and stop_at(e))
         sum_indices, factors = delta_elimination(sum_indices, factors, index_replacer=index_replacer)
         factors = [index_replacer(f, ()) for f in factors]
         if ignore is not None:

--- a/gem/optimise.py
+++ b/gem/optimise.py
@@ -398,10 +398,11 @@ def _independent_contractions(sum_indices, groups):
     parent = {index: index for index in sum_indices}
 
     def find(index):
-        while parent[index] != index:
-            parent[index] = parent[parent[index]]
-            index = parent[index]
-        return index
+        if parent[index] == index:
+            return index
+
+        parent[index] = find(parent[index])
+        return parent[index]
 
     index_set = set(sum_indices)
     shared = [[i for i in group.free_indices if i in index_set] for group in groups]

--- a/gem/optimise.py
+++ b/gem/optimise.py
@@ -382,25 +382,59 @@ def associate(operator, operands):
     return result, flops
 
 
-def sum_factorise(sum_indices, factors):
-    """Optimise a tensor product through sum factorisation.
+def _independent_contractions(sum_indices, groups):
+    """Split a contraction into independent subproblems.
+
+    Two contraction indices only interact if some factor carries both of
+    them, so the factors and the indices form a graph whose connected
+    components can be contracted separately.
 
     :arg sum_indices: free indices for contractions
-    :arg factors: product factors
+    :arg groups: product factors, grouped by free indices
+    :returns: a pair of the list of (indices, groups) subproblems and the
+              list of groups carrying no contraction index
+    """
+    # Union-find over the contraction indices
+    parent = {index: index for index in sum_indices}
+
+    def find(index):
+        while parent[index] != index:
+            parent[index] = parent[parent[index]]
+            index = parent[index]
+        return index
+
+    index_set = set(sum_indices)
+    shared = [[i for i in group.free_indices if i in index_set] for group in groups]
+    for indices in shared:
+        for index in indices[1:]:
+            root, other = find(indices[0]), find(index)
+            if root != other:
+                parent[other] = root
+
+    subproblems = OrderedDict((find(index), ([], [])) for index in sum_indices)
+    for index in sum_indices:
+        subproblems[find(index)][0].append(index)
+
+    rest = []
+    for group, indices in zip(groups, shared):
+        if indices:
+            subproblems[find(indices[0])][1].append(group)
+        else:
+            rest.append(group)
+    return list(subproblems.values()), rest
+
+
+def _sum_factorise_connected(sum_indices, groups):
+    """Sum factorise a single connected contraction by exhaustive search.
+
+    :arg sum_indices: free indices for contractions, which must not split
+                      into independent subproblems
+    :arg groups: product factors, grouped by free indices
     :returns: optimised GEM expression
     """
-    if len(factors) == 0 and len(sum_indices) == 0:
-        # Empty product
-        return one
-
     if len(sum_indices) > 6:
         raise NotImplementedError("Too many indices for sum factorisation!")
 
-    # Form groups by free indices
-    groups = groupby(factors, key=lambda f: f.free_indices)
-    groups = [Product(*terms) for _, terms in groups]
-
-    # Sum factorisation
     expression = None
     best_flops = numpy.inf
 
@@ -432,6 +466,33 @@ def sum_factorise(sum_indices, factors):
             expression = expr
             best_flops = flops
 
+    return expression
+
+
+def sum_factorise(sum_indices, factors):
+    """Optimise a tensor product through sum factorisation.
+
+    :arg sum_indices: free indices for contractions
+    :arg factors: product factors
+    :returns: optimised GEM expression
+    """
+    if len(factors) == 0 and len(sum_indices) == 0:
+        # Empty product
+        return one
+
+    # Form groups by free indices
+    groups = groupby(factors, key=lambda f: f.free_indices)
+    groups = [Product(*terms) for _, terms in groups]
+
+    # Contractions that share no factor are independent of each other, so
+    # factorise them separately rather than searching the orderings that
+    # interleave them.
+    subproblems, terms = _independent_contractions(sum_indices, groups)
+    terms = terms + [_sum_factorise_connected(indices, subgroups)
+                     for indices, subgroups in subproblems]
+    if not terms:
+        return one
+    expression, _ = associate(Product, terms)
     return expression
 
 

--- a/test/finat/test_dual_basis.py
+++ b/test/finat/test_dual_basis.py
@@ -3,6 +3,7 @@ import numpy
 import finat
 import gem
 from FIAT import ufc_simplex
+from gem.interpreter import evaluate
 
 
 @pytest.mark.parametrize("dim", (2, 3))
@@ -45,3 +46,69 @@ def test_enriched_element_dual_evaluation():
     assert isinstance(expr.children[0], gem.Concatenate)
     assert len(indices) == 1
     assert indices[0].extent == enriched.space_dimension()
+
+
+@pytest.fixture(scope="module")
+def hexahedron():
+    line = finat.Lagrange(ufc_simplex(1), 1)
+    return finat.TensorProductElement([finat.TensorProductElement([line, line]), line])
+
+
+def coefficient_evaluation(element, ps, dofs):
+    """Evaluate a coefficient at a point set, sum factorised as TSFC does."""
+    beta = element.get_indices()
+    zeta = element.get_value_indices()
+    dim = element.cell.get_spatial_dimension()
+    table = element.basis_evaluation(0, ps)[(0,) * dim]
+    dofs = gem.Literal(dofs.reshape([index.extent for index in beta]))
+    value = gem.Product(gem.Indexed(table, beta + zeta), gem.Indexed(dofs, beta))
+    return gem.ComponentTensor(gem.optimise.contraction(gem.IndexSum(value, beta)), zeta)
+
+
+def nodal_values(element, fn):
+    """Dual evaluate fn against a nodal element, giving its values at the nodes."""
+    expression, indices = element.dual_evaluation(fn)
+    result, = evaluate([gem.ComponentTensor(expression, indices)])
+    return result.arr
+
+
+@pytest.mark.parametrize("power", (2, 3, 4))
+def test_dual_evaluation_of_powers(hexahedron, power):
+    # Each evaluation contracts over the three tensor-product directions, so
+    # a product of them carries more indices than one sum factorisation can
+    # search.  The evaluations are already factorised, so keep them that way.
+    numpy.random.seed(0)
+    dofs = numpy.random.rand(hexahedron.space_dimension())
+
+    def evaluation(ps):
+        return coefficient_evaluation(hexahedron, ps, dofs)
+
+    def monomial(ps):
+        expression = evaluation(ps)
+        for _ in range(power - 1):
+            expression = gem.Product(expression, evaluation(ps))
+        return expression
+
+    assert numpy.allclose(nodal_values(hexahedron, monomial),
+                          nodal_values(hexahedron, evaluation) ** power)
+
+
+def test_dual_evaluation_of_coupled_evaluations(hexahedron):
+    # Contracting the value indices of two evaluations couples them into a
+    # single contraction, which no ordering of the factors can break up.
+    element = finat.TensorFiniteElement(hexahedron, (3,))
+    numpy.random.seed(0)
+    dofs = numpy.random.rand(element.space_dimension())
+
+    def evaluation(ps):
+        return coefficient_evaluation(element, ps, dofs)
+
+    def cubed(ps):
+        u = evaluation(ps)
+        i, j = gem.Index(extent=3), gem.Index(extent=3)
+        square = gem.IndexSum(gem.Product(gem.Indexed(u, (i,)), gem.Indexed(u, (i,))), (i,))
+        return gem.ComponentTensor(gem.Product(square, gem.Indexed(u, (j,))), (j,))
+
+    values = nodal_values(element, evaluation)
+    expected = numpy.einsum("...i,...i->...", values, values)[..., None] * values
+    assert numpy.allclose(nodal_values(element, cubed), expected)

--- a/test/gem/test_sum_factorise.py
+++ b/test/gem/test_sum_factorise.py
@@ -3,6 +3,8 @@ import pytest
 
 import gem
 from gem.interpreter import evaluate
+from gem import optimise
+from gem.node import traversal
 from gem.optimise import sum_factorise
 
 
@@ -50,3 +52,33 @@ def test_too_many_indices_in_one_contraction():
     table = gem.Indexed(gem.Literal(numpy.ones((2,) * 7)), indices)
     with pytest.raises(NotImplementedError):
         sum_factorise(indices, [table])
+
+
+def test_contraction_preserves_factorised_contractions():
+    # A dual evaluation contracts the weights with an expression whose
+    # coefficient evaluations are already sum factorised.  Those carry the
+    # point index of the contraction, so flattening them yields a single
+    # connected contraction that is too large to factorise.
+    numpy.random.seed(0)
+    p, q = gem.Index(extent=4), gem.Index(extent=4)
+    ijk = tuple(gem.Index(extent=3) for _ in range(3))
+
+    table = gem.Indexed(gem.Literal(numpy.random.rand(3, 3, 3, 4)), ijk + (p,))
+    dofs = numpy.random.rand(3, 3, 3)
+    evaluation = optimise.contraction(gem.IndexSum(gem.Product(table, gem.Indexed(gem.Literal(dofs), ijk)), ijk))
+    assert optimise.is_contraction(evaluation)
+
+    weights = numpy.random.rand(4, 4)
+    cubed = gem.Product(gem.Product(gem.Indexed(gem.Literal(weights), (q, p)), evaluation),
+                        gem.Product(evaluation, evaluation))
+    expression = gem.IndexSum(cubed, (p,))
+
+    with pytest.raises(NotImplementedError):
+        optimise.contraction(expression)
+
+    optimised = optimise.contraction(expression, stop_at=optimise.is_contraction)
+    assert evaluation in set(traversal([optimised]))
+
+    result, = evaluate([gem.ComponentTensor(optimised, (q,))])
+    expected = weights.dot(numpy.einsum("ijkp,ijk->p", numpy.asarray(table.children[0].array), dofs) ** 3)
+    assert numpy.allclose(result.arr, expected)

--- a/test/gem/test_sum_factorise.py
+++ b/test/gem/test_sum_factorise.py
@@ -1,0 +1,52 @@
+import numpy
+import pytest
+
+import gem
+from gem.interpreter import evaluate
+from gem.optimise import sum_factorise
+
+
+def contraction(nfactors, ndims, extent=2):
+    """Build a product of independent contractions.
+
+    Each factor contracts a table with a coefficient over its own indices,
+    as a tensor product coefficient evaluation does, so no factor carries
+    the indices of another.
+    """
+    numpy.random.seed(0)
+    sum_indices = []
+    factors = []
+    expected = 1.0
+    for _ in range(nfactors):
+        indices = tuple(gem.Index(extent=extent) for _ in range(ndims))
+        table = numpy.random.rand(*(extent,) * ndims)
+        coefficient = numpy.random.rand(*(extent,) * ndims)
+        factors.append(gem.Indexed(gem.Literal(table), indices))
+        factors.append(gem.Indexed(gem.Literal(coefficient), indices))
+        sum_indices.extend(indices)
+        expected *= numpy.sum(table * coefficient)
+    return tuple(sum_indices), factors, expected
+
+
+@pytest.mark.parametrize("nfactors,ndims", [(1, 3), (2, 3), (3, 3), (5, 3), (3, 5)])
+def test_independent_contractions(nfactors, ndims):
+    # Contractions that share no factor are independent, so they are
+    # factorised separately rather than by searching the orderings that
+    # interleave them.  Together they exceed what one exhaustive search
+    # can handle.
+    sum_indices, factors, expected = contraction(nfactors, ndims)
+    assert len(sum_indices) == nfactors * ndims
+
+    expression = sum_factorise(sum_indices, factors)
+    assert expression.free_indices == ()
+
+    result, = evaluate([expression])
+    assert numpy.allclose(result.arr, expected)
+
+
+def test_too_many_indices_in_one_contraction():
+    # A single connected contraction is still bounded.
+    indices = tuple(gem.Index(extent=2) for _ in range(7))
+    table = gem.Indexed(gem.Literal(numpy.ones((2,) * 7)), indices)
+    with pytest.raises(NotImplementedError):
+        sum_factorise(indices, [table])


### PR DESCRIPTION
Stacked on #269.

TLDR: interpolation was undoing sum-factorisation from the source expression and refactorising it after computing the degrees of freedom. This PR preserves the original sum-factorization by stopping early when traversing a contracted GEM expression.

TSFC hands FInAT's dual evaluation coefficient evaluations that are already sum factorised, and `traverse_product` flattened them back into the surrounding contraction, undoing sum-factorization. That discarded the factorisation along with the subexpressions the factors shared, and multiplied the indices to search over, so a product of a few evaluations exceeded the sum factorisation limit.

This PR makes contractions atomic: the new `gem.optimise.is_contraction` predicate is passed as `stop_at`, so an already factorised contraction is not flattened. Bounding the index count this way retires the `ignore` argument of `contraction`, along with the shape-index workaround that was its only user.

Kernel flop counts for interpolation on a hexahedron, where error is `NotImplementedError: Too many indices for sum factorisation!`:

| interpolate | before | after |
| --- | --- | --- |
| `f*f*f`, CG1 → CG1 | 96 | 96 |
| `f*f`, CG4 → DG3 | 5008 | 2568 |
| `dot(u, u)*u`, vector CG4 → vector CG4 | error | 23875 |
| `dot(A, A)`, tensor CG2 → tensor CG3 | error | 16776 |
| `inner(A, A)`, tensor CG2 → CG2 | error | 4131 |
| `grad(f)[0]`, CG4 → CG4 | 13981 | 14106 |
| `div(u)`, vector CG4 → DG3 | 23100 | 23548 |

Tests are added for the GEM and FInAT paths.

AI declaration: written with Claude Code (Claude Opus 5).
