### PR TITLE
Recognise repeated and joined contractions when sum factorising

### DIFF
--- a/finat/finiteelementbase.py
+++ b/finat/finiteelementbase.py
@@ -279,7 +279,7 @@ class FiniteElementBase(metaclass=ABCMeta):
         Qi = Q[basis_indices + shape_indices]
         expri = expr[shape_indices]
         evaluation = gem.IndexSum(Qi * expri, x.indices + shape_indices)
-        # Factorise over the new contraction with x, keeping whole the
+        # Factorise over the new contraction with Qi, keeping whole the
         # contractions that fn already factorised
         evaluation = gem.optimise.contraction(evaluation, stop_at=is_contraction)
         return evaluation, basis_indices

--- a/finat/finiteelementbase.py
+++ b/finat/finiteelementbase.py
@@ -4,7 +4,8 @@ from itertools import chain
 import gem
 import numpy
 from gem.interpreter import evaluate
-from gem.optimise import delta_elimination, sum_factorise, traverse_product
+from gem.optimise import (delta_elimination, is_contraction, sum_factorise,
+                          traverse_product)
 from gem.utils import cached_property
 
 from finat.quadrature import make_quadrature
@@ -266,8 +267,9 @@ class FiniteElementBase(metaclass=ABCMeta):
 
         expr = fn(x)
         # Apply targeted sum factorisation and delta elimination to
-        # the expression
-        sum_indices, factors = delta_elimination(*traverse_product(expr))
+        # the expression, preserving contractions that fn already
+        # factorised
+        sum_indices, factors = delta_elimination(*traverse_product(expr, stop_at=is_contraction))
         expr = sum_factorise(sum_indices, factors)
         # NOTE: any shape indices in the expression are because the
         # expression is tensor valued.
@@ -281,7 +283,8 @@ class FiniteElementBase(metaclass=ABCMeta):
         # ignoring any shape indices to avoid hitting the sum-
         # factorisation index limit (this is a bit of a hack).
         # Really need to do a more targeted job here.
-        evaluation = gem.optimise.contraction(evaluation, shape_indices)
+        evaluation = gem.optimise.contraction(evaluation, shape_indices,
+                                              stop_at=is_contraction)
         return evaluation, basis_indices
 
     def dual_transformation(self, Q, coordinate_mapping=None):

--- a/finat/finiteelementbase.py
+++ b/finat/finiteelementbase.py
@@ -279,12 +279,9 @@ class FiniteElementBase(metaclass=ABCMeta):
         Qi = Q[basis_indices + shape_indices]
         expri = expr[shape_indices]
         evaluation = gem.IndexSum(Qi * expri, x.indices + shape_indices)
-        # Now we want to factorise over the new contraction with x,
-        # ignoring any shape indices to avoid hitting the sum-
-        # factorisation index limit (this is a bit of a hack).
-        # Really need to do a more targeted job here.
-        evaluation = gem.optimise.contraction(evaluation, shape_indices,
-                                              stop_at=is_contraction)
+        # Factorise over the new contraction with x, keeping whole the
+        # contractions that fn already factorised
+        evaluation = gem.optimise.contraction(evaluation, stop_at=is_contraction)
         return evaluation, basis_indices
 
     def dual_transformation(self, Q, coordinate_mapping=None):

--- a/finat/finiteelementbase.py
+++ b/finat/finiteelementbase.py
@@ -4,8 +4,6 @@ from itertools import chain
 import gem
 import numpy
 from gem.interpreter import evaluate
-from gem.optimise import (delta_elimination, is_contraction, sum_factorise,
-                          traverse_product)
 from gem.utils import cached_property
 
 from finat.quadrature import make_quadrature
@@ -266,10 +264,6 @@ class FiniteElementBase(metaclass=ABCMeta):
         Q = self.dual_transformation(Q, coordinate_mapping=coordinate_mapping)
 
         expr = fn(x)
-        # Apply targeted sum factorisation and delta elimination to
-        # the expression, preserving contractions that fn already factorised
-        sum_indices, factors = delta_elimination(*traverse_product(expr, stop_at=is_contraction))
-        expr = sum_factorise(sum_indices, factors)
         # NOTE: any shape indices in the expression are because the
         # expression is tensor valued.
         assert expr.shape == Q.shape[len(Q.shape)-len(expr.shape):]
@@ -278,9 +272,7 @@ class FiniteElementBase(metaclass=ABCMeta):
         Qi = Q[basis_indices + shape_indices]
         expri = expr[shape_indices]
         evaluation = gem.IndexSum(Qi * expri, x.indices + shape_indices)
-        # Factorise over the new contraction with Qi, keeping whole the
-        # contractions that fn already factorised
-        evaluation = gem.optimise.contraction(evaluation, stop_at=is_contraction)
+        evaluation = gem.optimise.contraction(evaluation)
         return evaluation, basis_indices
 
     def dual_transformation(self, Q, coordinate_mapping=None):

--- a/finat/finiteelementbase.py
+++ b/finat/finiteelementbase.py
@@ -267,8 +267,7 @@ class FiniteElementBase(metaclass=ABCMeta):
 
         expr = fn(x)
         # Apply targeted sum factorisation and delta elimination to
-        # the expression, preserving contractions that fn already
-        # factorised
+        # the expression, preserving contractions that fn already factorised
         sum_indices, factors = delta_elimination(*traverse_product(expr, stop_at=is_contraction))
         expr = sum_factorise(sum_indices, factors)
         # NOTE: any shape indices in the expression are because the

--- a/finat/tensorfiniteelement.py
+++ b/finat/tensorfiniteelement.py
@@ -3,7 +3,8 @@ from itertools import chain
 import numpy
 
 import gem
-from gem.optimise import delta_elimination, sum_factorise, traverse_product
+from gem.optimise import (delta_elimination, is_contraction, sum_factorise,
+                          traverse_product)
 from gem.utils import cached_property
 
 from finat.finiteelementbase import FiniteElementBase
@@ -177,8 +178,9 @@ class TensorFiniteElement(FiniteElementBase):
 
         expr = fn(x)
         # Apply targeted sum factorisation and delta elimination to
-        # the expression
-        sum_indices, factors = delta_elimination(*traverse_product(expr))
+        # the expression, preserving contractions that fn already
+        # factorised
+        sum_indices, factors = delta_elimination(*traverse_product(expr, stop_at=is_contraction))
         expr = sum_factorise(sum_indices, factors)
         # NOTE: any shape indices in the expression are because the
         # expression is tensor valued.
@@ -200,7 +202,7 @@ class TensorFiniteElement(FiniteElementBase):
         # This doesn't work perfectly, the resulting code doesn't have
         # a minimal memory footprint, although the operation count
         # does appear to be minimal.
-        evaluation = gem.optimise.contraction(evaluation)
+        evaluation = gem.optimise.contraction(evaluation, stop_at=is_contraction)
         return evaluation, scalar_i + tensor_vi
 
     @property

--- a/finat/tensorfiniteelement.py
+++ b/finat/tensorfiniteelement.py
@@ -178,8 +178,7 @@ class TensorFiniteElement(FiniteElementBase):
 
         expr = fn(x)
         # Apply targeted sum factorisation and delta elimination to
-        # the expression, preserving contractions that fn already
-        # factorised
+        # the expression, preserving contractions that fn already factorised
         sum_indices, factors = delta_elimination(*traverse_product(expr, stop_at=is_contraction))
         expr = sum_factorise(sum_indices, factors)
         # NOTE: any shape indices in the expression are because the

--- a/finat/tensorfiniteelement.py
+++ b/finat/tensorfiniteelement.py
@@ -3,8 +3,6 @@ from itertools import chain
 import numpy
 
 import gem
-from gem.optimise import (delta_elimination, is_contraction, sum_factorise,
-                          traverse_product)
 from gem.utils import cached_property
 
 from finat.finiteelementbase import FiniteElementBase
@@ -177,10 +175,6 @@ class TensorFiniteElement(FiniteElementBase):
         tQ = self._base_element.dual_transformation(tQ, coordinate_mapping)
 
         expr = fn(x)
-        # Apply targeted sum factorisation and delta elimination to
-        # the expression, preserving contractions that fn already factorised
-        sum_indices, factors = delta_elimination(*traverse_product(expr, stop_at=is_contraction))
-        expr = sum_factorise(sum_indices, factors)
         # NOTE: any shape indices in the expression are because the
         # expression is tensor valued.
         assert expr.shape == self.value_shape
@@ -198,10 +192,7 @@ class TensorFiniteElement(FiniteElementBase):
         tQi = tQ[index_ordering]
         expri = expr[tensor_i + scalar_vi]
         evaluation = gem.IndexSum(tQi * expri, x.indices + scalar_vi + tensor_i)
-        # This doesn't work perfectly, the resulting code doesn't have
-        # a minimal memory footprint, although the operation count
-        # does appear to be minimal.
-        evaluation = gem.optimise.contraction(evaluation, stop_at=is_contraction)
+        evaluation = gem.optimise.contraction(evaluation)
         return evaluation, scalar_i + tensor_vi
 
     @property

--- a/gem/optimise.py
+++ b/gem/optimise.py
@@ -493,14 +493,13 @@ def _plan_contraction(sum_indices, groups):
             expression = IndexSum(expression, indices)
         return expression, free, flops
 
-    # plans[subset] = (flops, peak intermediate size, expression, free indices)
+    # plans[subset] = (flops, expression, free indices)
     plans = {}
     for n, group in enumerate(groups):
         subset = 1 << n
         free = frozenset(group.free_indices)
-        peak = size(free)
         expression, free, flops = reduce_indices(group, free, reducible[subset])
-        plans[subset] = (flops, peak, expression, free)
+        plans[subset] = (flops, expression, free)
 
     for subset in range(1, full + 1):
         if subset in plans:
@@ -513,19 +512,18 @@ def _plan_contraction(sum_indices, groups):
             if part & lowest:
                 other = subset ^ part
                 left, right = plans[part], plans[other]
-                free = left[3] | right[3]
+                free = left[2] | right[2]
                 flops = left[0] + right[0] + size(free)
-                peak = max(left[1], right[1], size(free))
-                expression = Product(left[2], right[2])
+                expression = Product(left[1], right[1])
                 indices = reducible[subset] - reducible[part] - reducible[other]
                 expression, free, extra = reduce_indices(expression, free, indices)
-                candidate = (flops + extra, peak, expression, free)
-                if best is None or candidate[:2] < best[:2]:
+                candidate = (flops + extra, expression, free)
+                if best is None or candidate[0] < best[0]:
                     best = candidate
             part = (part - 1) & subset
         plans[subset] = best
 
-    return plans[full][2]
+    return plans[full][1]
 
 
 def _sum_factorise_connected(sum_indices, groups):
@@ -539,7 +537,7 @@ def _sum_factorise_connected(sum_indices, groups):
     if len(groups) <= _MAX_PLANNED_FACTORS:
         return _plan_contraction(sum_indices, groups)
 
-    if len(sum_indices) > 10:
+    if len(sum_indices) > 6:
         raise NotImplementedError("Too many indices for sum factorisation!")
 
     expression = None

--- a/gem/optimise.py
+++ b/gem/optimise.py
@@ -654,17 +654,13 @@ def is_contraction(expression: Node) -> bool:
     return isinstance(expression, IndexSum)
 
 
-def contraction(expression, ignore=None, stop_at=None):
+def contraction(expression, stop_at=None):
     """Optimise the contractions of the tensor product at the root of
     the expression, including:
 
     - IndexSum-Delta cancellation
     - Sum factorisation
 
-    :arg ignore: Optional set of indices to ignore when applying sum
-        factorisation (otherwise all summation indices will be
-        considered). Use this if your expression has many contraction
-        indices.
     :arg stop_at: Optional predicate on GEM expressions that are not to
         be broken into further factors, see :func:`traverse_product`.
         The contraction at the root is always broken up, as that is the
@@ -688,15 +684,7 @@ def contraction(expression, ignore=None, stop_at=None):
             stop_at=None if stop_at is None else lambda e: e is not root and stop_at(e))
         sum_indices, factors = delta_elimination(sum_indices, factors, index_replacer=index_replacer)
         factors = [index_replacer(f, ()) for f in factors]
-        if ignore is not None:
-            # TODO: This is a really blunt instrument and one might
-            # plausibly want the ignored indices to be contracted on
-            # the inside rather than the outside.
-            extra = tuple(i for i in sum_indices if i in ignore)
-            to_factor = tuple(i for i in sum_indices if i not in ignore)
-            return IndexSum(sum_factorise(to_factor, factors), extra)
-        else:
-            return sum_factorise(sum_indices, factors)
+        return sum_factorise(sum_indices, factors)
 
     # Sometimes the value shape is composed as a ListTensor, which
     # could get in the way of decomposing factors.  In particular,

--- a/gem/optimise.py
+++ b/gem/optimise.py
@@ -1,7 +1,7 @@
 """A set of routines implementing various transformations on GEM
 expressions."""
 
-from collections import OrderedDict, defaultdict
+from collections import Counter, OrderedDict, defaultdict
 from functools import singledispatch, partial
 from itertools import combinations, permutations, zip_longest
 from numbers import Integral
@@ -654,6 +654,41 @@ def is_contraction(expression: Node) -> bool:
     return isinstance(expression, IndexSum)
 
 
+def repeated_contractions(expression):
+    """Find the contractions that occur more than once in a product tree.
+
+    Parameters
+    ----------
+    expression :
+        A GEM expression.
+
+    Returns
+    -------
+    frozenset
+        The :class:`~.IndexSum` nodes occurring more than once as a
+        factor of ``expression``.
+
+    Notes
+    -----
+    Flattening a contraction renames its indices apart, so a contraction
+    used more than once becomes that many independent contractions and
+    is evaluated once per use.  Keeping it whole preserves the sharing.
+
+    """
+    counts = Counter()
+    stack = [expression]
+    while stack:
+        expr = stack.pop()
+        if isinstance(expr, IndexSum):
+            counts[expr] += 1
+            stack.extend(expr.children)
+        elif isinstance(expr, Product):
+            stack.extend(expr.children)
+        elif isinstance(expr, Division):
+            stack.append(expr.children[0])
+    return frozenset(expr for expr, count in counts.items() if count > 1)
+
+
 def contraction(expression, stop_at=None):
     """Optimise the contractions of the tensor product at the root of
     the expression, including:
@@ -679,9 +714,11 @@ def contraction(expression, stop_at=None):
     # Flatten product tree, eliminate deltas, sum factorise
     def rebuild(expression):
         root = expression
+        keep = repeated_contractions(expression) if stop_at is None else None
+        predicate = keep.__contains__ if keep is not None else stop_at
         sum_indices, factors = traverse_product(
             expression, index_replacer=index_replacer,
-            stop_at=None if stop_at is None else lambda e: e is not root and stop_at(e))
+            stop_at=lambda e: e is not root and predicate(e))
         sum_indices, factors = delta_elimination(sum_indices, factors, index_replacer=index_replacer)
         factors = [index_replacer(f, ()) for f in factors]
         return sum_factorise(sum_indices, factors)

--- a/gem/optimise.py
+++ b/gem/optimise.py
@@ -630,7 +630,31 @@ def traverse_sum(expression, stop_at=None):
     return result
 
 
-def contraction(expression, ignore=None):
+def is_contraction(expression: Node) -> bool:
+    """Test whether an expression is a tensor contraction.
+
+    Parameters
+    ----------
+    expression :
+        A GEM expression.
+
+    Returns
+    -------
+    bool
+        Whether the expression is a contraction.
+
+    Notes
+    -----
+    Pass this as ``stop_at`` to keep a contraction that is already sum
+    factorised out of a surrounding one. Flattening it discards its
+    factorisation, along with any subexpression it shares with another
+    factor, and inflates the number of indices to factorise over.
+
+    """
+    return isinstance(expression, IndexSum)
+
+
+def contraction(expression, ignore=None, stop_at=None):
     """Optimise the contractions of the tensor product at the root of
     the expression, including:
 
@@ -641,6 +665,10 @@ def contraction(expression, ignore=None):
         factorisation (otherwise all summation indices will be
         considered). Use this if your expression has many contraction
         indices.
+    :arg stop_at: Optional predicate on GEM expressions that are not to
+        be broken into further factors, see :func:`traverse_product`.
+        The contraction at the root is always broken up, as that is the
+        one being optimised.
 
     This routine was designed with finite element coefficient
     evaluation in mind.
@@ -654,7 +682,10 @@ def contraction(expression, ignore=None):
 
     # Flatten product tree, eliminate deltas, sum factorise
     def rebuild(expression):
-        sum_indices, factors = traverse_product(expression, index_replacer=index_replacer)
+        root = expression
+        sum_indices, factors = traverse_product(
+            expression, index_replacer=index_replacer,
+            stop_at=None if stop_at is None else lambda e: e is not root and stop_at(e))
         sum_indices, factors = delta_elimination(sum_indices, factors, index_replacer=index_replacer)
         factors = [index_replacer(f, ()) for f in factors]
         if ignore is not None:

--- a/gem/optimise.py
+++ b/gem/optimise.py
@@ -398,10 +398,11 @@ def _independent_contractions(sum_indices, groups):
     parent = {index: index for index in sum_indices}
 
     def find(index):
-        while parent[index] != index:
-            parent[index] = parent[parent[index]]
-            index = parent[index]
-        return index
+        if parent[index] == index:
+            return index
+
+        parent[index] = find(parent[index])
+        return parent[index]
 
     index_set = set(sum_indices)
     shared = [[i for i in group.free_indices if i in index_set] for group in groups]

--- a/gem/optimise.py
+++ b/gem/optimise.py
@@ -425,6 +425,104 @@ def _independent_contractions(sum_indices, groups):
     return list(subproblems.values()), rest
 
 
+#: Largest number of factors for which a product tree is planned exactly.
+_MAX_PLANNED_FACTORS = 10
+
+
+def _plan_contraction(sum_indices, groups):
+    """Choose a product tree for one connected contraction.
+
+    Parameters
+    ----------
+    sum_indices :
+        Contraction indices of a single connected subproblem.
+    groups :
+        Product factors, grouped by free indices.
+
+    Returns
+    -------
+    Node
+        The contracted GEM expression.
+
+    Notes
+    -----
+    Every factor is a vertex and every contraction index joins the
+    factors carrying it.  A product tree is built by dynamic programming
+    over subsets of factors, and each index is reduced at the smallest
+    subtree holding every factor that carries it, which is the earliest
+    its reduction is legal.  Unlike a search over orderings of the
+    indices, this can reduce an index over part of the product and
+    multiply the rest in afterwards.
+
+    """
+    extents = {}
+    for index in sum_indices:
+        extents[index] = index.extent
+    for group in groups:
+        for index in group.free_indices:
+            extents[index] = index.extent
+
+    def size(indices):
+        return numpy.prod([extents[i] for i in indices], dtype=int)
+
+    # The factors each contraction index occurs in, as a bit mask
+    incidence = {}
+    for index in sum_indices:
+        incidence[index] = sum(1 << n for n, group in enumerate(groups)
+                               if index in group.free_indices)
+
+    full = (1 << len(groups)) - 1
+    # Indices reducible once a subset of the factors has been multiplied
+    reducible = {}
+    for subset in range(1, full + 1):
+        reducible[subset] = frozenset(index for index in sum_indices
+                                      if not incidence[index] & ~subset)
+
+    def reduce_indices(expression, free, indices):
+        """Sum out indices, largest extent first, costing each reduction."""
+        flops = 0
+        for index in sorted(indices, key=lambda i: extents[i], reverse=True):
+            flops += size(free)
+            free = free - {index}
+        if indices:
+            expression = IndexSum(expression, tuple(indices))
+        return expression, free, flops
+
+    # plans[subset] = (flops, peak intermediate size, expression, free indices)
+    plans = {}
+    for n, group in enumerate(groups):
+        subset = 1 << n
+        free = frozenset(group.free_indices)
+        peak = size(free)
+        expression, free, flops = reduce_indices(group, free, reducible[subset])
+        plans[subset] = (flops, peak, expression, free)
+
+    for subset in range(1, full + 1):
+        if subset in plans:
+            continue
+        best = None
+        # Split the subset in two, taking each unordered split once
+        lowest = subset & -subset
+        part = (subset - 1) & subset
+        while part:
+            if part & lowest:
+                other = subset ^ part
+                left, right = plans[part], plans[other]
+                free = left[3] | right[3]
+                flops = left[0] + right[0] + size(free)
+                peak = max(left[1], right[1], size(free))
+                expression = Product(left[2], right[2])
+                indices = reducible[subset] - reducible[part] - reducible[other]
+                expression, free, extra = reduce_indices(expression, free, indices)
+                candidate = (flops + extra, peak, expression, free)
+                if best is None or candidate[:2] < best[:2]:
+                    best = candidate
+            part = (part - 1) & subset
+        plans[subset] = best
+
+    return plans[full][2]
+
+
 def _sum_factorise_connected(sum_indices, groups):
     """Sum factorise a single connected contraction by exhaustive search.
 
@@ -433,6 +531,9 @@ def _sum_factorise_connected(sum_indices, groups):
     :arg groups: product factors, grouped by free indices
     :returns: optimised GEM expression
     """
+    if len(groups) <= _MAX_PLANNED_FACTORS:
+        return _plan_contraction(sum_indices, groups)
+
     if len(sum_indices) > 10:
         raise NotImplementedError("Too many indices for sum factorisation!")
 

--- a/gem/optimise.py
+++ b/gem/optimise.py
@@ -769,17 +769,12 @@ def repeated_contractions(expression):
     return frozenset(expr for expr, count in counts.items() if count > 1)
 
 
-def contraction(expression, stop_at=None):
+def contraction(expression):
     """Optimise the contractions of the tensor product at the root of
     the expression, including:
 
     - IndexSum-Delta cancellation
     - Sum factorisation
-
-    :arg stop_at: Optional predicate on GEM expressions that are not to
-        be broken into further factors, see :func:`traverse_product`.
-        The contraction at the root is always broken up, as that is the
-        one being optimised.
 
     This routine was designed with finite element coefficient
     evaluation in mind.
@@ -794,11 +789,12 @@ def contraction(expression, stop_at=None):
     # Flatten product tree, eliminate deltas, sum factorise
     def rebuild(expression):
         root = expression
-        keep = repeated_contractions(expression) if stop_at is None else None
-        predicate = keep.__contains__ if keep is not None else stop_at
+        # The contraction at the root is always broken up, as that is the
+        # one being optimised
+        keep = repeated_contractions(expression)
         sum_indices, factors = traverse_product(
             expression, index_replacer=index_replacer,
-            stop_at=lambda e: e is not root and predicate(e))
+            stop_at=lambda e: e is not root and e in keep)
         sum_indices, factors = delta_elimination(sum_indices, factors, index_replacer=index_replacer)
         factors = [index_replacer(f, ()) for f in factors]
         return sum_factorise(sum_indices, factors)

--- a/gem/optimise.py
+++ b/gem/optimise.py
@@ -478,14 +478,19 @@ def _plan_contraction(sum_indices, groups):
         reducible[subset] = frozenset(index for index in sum_indices
                                       if not incidence[index] & ~subset)
 
+    def order(indices):
+        """Sum out the widest index first, breaking ties reproducibly."""
+        return tuple(sorted(indices, key=lambda i: (-extents[i], i.count)))
+
     def reduce_indices(expression, free, indices):
         """Sum out indices, largest extent first, costing each reduction."""
         flops = 0
-        for index in sorted(indices, key=lambda i: extents[i], reverse=True):
+        indices = order(indices)
+        for index in indices:
             flops += size(free)
             free = free - {index}
         if indices:
-            expression = IndexSum(expression, tuple(indices))
+            expression = IndexSum(expression, indices)
         return expression, free, flops
 
     # plans[subset] = (flops, peak intermediate size, expression, free indices)

--- a/gem/optimise.py
+++ b/gem/optimise.py
@@ -428,12 +428,12 @@ def _independent_contractions(sum_indices, groups):
 def _sum_factorise_connected(sum_indices, groups):
     """Sum factorise a single connected contraction by exhaustive search.
 
-    :arg sum_indices: free indices for contractions, which must not split
+    :arg sum_indices: free indices for contractions, already split
                       into independent subproblems
     :arg groups: product factors, grouped by free indices
     :returns: optimised GEM expression
     """
-    if len(sum_indices) > 6:
+    if len(sum_indices) > 10:
         raise NotImplementedError("Too many indices for sum factorisation!")
 
     expression = None

--- a/gem/optimise.py
+++ b/gem/optimise.py
@@ -734,30 +734,6 @@ def traverse_sum(expression, stop_at=None):
     return result
 
 
-def is_contraction(expression: Node) -> bool:
-    """Test whether an expression is a tensor contraction.
-
-    Parameters
-    ----------
-    expression :
-        A GEM expression.
-
-    Returns
-    -------
-    bool
-        Whether the expression is a contraction.
-
-    Notes
-    -----
-    Pass this as ``stop_at`` to keep a contraction that is already sum
-    factorised out of a surrounding one. Flattening it discards its
-    factorisation, along with any subexpression it shares with another
-    factor, and inflates the number of indices to factorise over.
-
-    """
-    return isinstance(expression, IndexSum)
-
-
 def repeated_contractions(expression):
     """Find the contractions that occur more than once in a product tree.
 

--- a/gem/optimise.py
+++ b/gem/optimise.py
@@ -382,25 +382,59 @@ def associate(operator, operands):
     return result, flops
 
 
-def sum_factorise(sum_indices, factors):
-    """Optimise a tensor product through sum factorisation.
+def _independent_contractions(sum_indices, groups):
+    """Split a contraction into independent subproblems.
+
+    Two contraction indices only interact if some factor carries both of
+    them, so the factors and the indices form a graph whose connected
+    components can be contracted separately.
 
     :arg sum_indices: free indices for contractions
-    :arg factors: product factors
+    :arg groups: product factors, grouped by free indices
+    :returns: a pair of the list of (indices, groups) subproblems and the
+              list of groups carrying no contraction index
+    """
+    # Union-find over the contraction indices
+    parent = {index: index for index in sum_indices}
+
+    def find(index):
+        while parent[index] != index:
+            parent[index] = parent[parent[index]]
+            index = parent[index]
+        return index
+
+    index_set = set(sum_indices)
+    shared = [[i for i in group.free_indices if i in index_set] for group in groups]
+    for indices in shared:
+        for index in indices[1:]:
+            root, other = find(indices[0]), find(index)
+            if root != other:
+                parent[other] = root
+
+    subproblems = OrderedDict((find(index), ([], [])) for index in sum_indices)
+    for index in sum_indices:
+        subproblems[find(index)][0].append(index)
+
+    rest = []
+    for group, indices in zip(groups, shared):
+        if indices:
+            subproblems[find(indices[0])][1].append(group)
+        else:
+            rest.append(group)
+    return list(subproblems.values()), rest
+
+
+def _sum_factorise_connected(sum_indices, groups):
+    """Sum factorise a single connected contraction by exhaustive search.
+
+    :arg sum_indices: free indices for contractions, which must not split
+                      into independent subproblems
+    :arg groups: product factors, grouped by free indices
     :returns: optimised GEM expression
     """
-    if len(factors) == 0 and len(sum_indices) == 0:
-        # Empty product
-        return one
-
     if len(sum_indices) > 6:
         raise NotImplementedError("Too many indices for sum factorisation!")
 
-    # Form groups by free indices
-    groups = groupby(factors, key=lambda f: f.free_indices)
-    groups = [Product(*terms) for _, terms in groups]
-
-    # Sum factorisation
     expression = None
     best_flops = numpy.inf
 
@@ -432,6 +466,33 @@ def sum_factorise(sum_indices, factors):
             expression = expr
             best_flops = flops
 
+    return expression
+
+
+def sum_factorise(sum_indices, factors):
+    """Optimise a tensor product through sum factorisation.
+
+    :arg sum_indices: free indices for contractions
+    :arg factors: product factors
+    :returns: optimised GEM expression
+    """
+    if len(factors) == 0 and len(sum_indices) == 0:
+        # Empty product
+        return one
+
+    # Form groups by free indices
+    groups = groupby(factors, key=lambda f: f.free_indices)
+    groups = [Product(*terms) for _, terms in groups]
+
+    # Contractions that share no factor are independent of each other, so
+    # factorise them separately rather than searching the orderings that
+    # interleave them.
+    subproblems, terms = _independent_contractions(sum_indices, groups)
+    terms = terms + [_sum_factorise_connected(indices, subgroups)
+                     for indices, subgroups in subproblems]
+    if not terms:
+        return one
+    expression, _ = associate(Product, terms)
     return expression
 
 

--- a/test/finat/test_dual_basis.py
+++ b/test/finat/test_dual_basis.py
@@ -3,6 +3,7 @@ import numpy
 import finat
 import gem
 from FIAT import ufc_simplex
+from gem.interpreter import evaluate
 
 
 @pytest.mark.parametrize("dim", (2, 3))
@@ -45,3 +46,69 @@ def test_enriched_element_dual_evaluation():
     assert isinstance(expr.children[0], gem.Concatenate)
     assert len(indices) == 1
     assert indices[0].extent == enriched.space_dimension()
+
+
+@pytest.fixture(scope="module")
+def hexahedron():
+    line = finat.Lagrange(ufc_simplex(1), 1)
+    return finat.TensorProductElement([finat.TensorProductElement([line, line]), line])
+
+
+def coefficient_evaluation(element, ps, dofs):
+    """Evaluate a coefficient at a point set, sum factorised as TSFC does."""
+    beta = element.get_indices()
+    zeta = element.get_value_indices()
+    dim = element.cell.get_spatial_dimension()
+    table = element.basis_evaluation(0, ps)[(0,) * dim]
+    dofs = gem.Literal(dofs.reshape([index.extent for index in beta]))
+    value = gem.Product(gem.Indexed(table, beta + zeta), gem.Indexed(dofs, beta))
+    return gem.ComponentTensor(gem.optimise.contraction(gem.IndexSum(value, beta)), zeta)
+
+
+def nodal_values(element, fn):
+    """Dual evaluate fn against a nodal element, giving its values at the nodes."""
+    expression, indices = element.dual_evaluation(fn)
+    result, = evaluate([gem.ComponentTensor(expression, indices)])
+    return result.arr
+
+
+@pytest.mark.parametrize("power", (2, 3, 4))
+def test_dual_evaluation_of_powers(hexahedron, power):
+    # Each evaluation contracts over the three tensor-product directions, so
+    # a product of them carries more indices than one sum factorisation can
+    # search.  The evaluations are already factorised, so keep them that way.
+    numpy.random.seed(0)
+    dofs = numpy.random.rand(hexahedron.space_dimension())
+
+    def evaluation(ps):
+        return coefficient_evaluation(hexahedron, ps, dofs)
+
+    def monomial(ps):
+        expression = evaluation(ps)
+        for _ in range(power - 1):
+            expression = gem.Product(expression, evaluation(ps))
+        return expression
+
+    assert numpy.allclose(nodal_values(hexahedron, monomial),
+                          nodal_values(hexahedron, evaluation) ** power)
+
+
+def test_dual_evaluation_of_coupled_evaluations(hexahedron):
+    # Contracting the value indices of two evaluations couples them into a
+    # single contraction, which no ordering of the factors can break up.
+    element = finat.TensorFiniteElement(hexahedron, (3,))
+    numpy.random.seed(0)
+    dofs = numpy.random.rand(element.space_dimension())
+
+    def evaluation(ps):
+        return coefficient_evaluation(element, ps, dofs)
+
+    def cubed(ps):
+        u = evaluation(ps)
+        i, j = gem.Index(extent=3), gem.Index(extent=3)
+        square = gem.IndexSum(gem.Product(gem.Indexed(u, (i,)), gem.Indexed(u, (i,))), (i,))
+        return gem.ComponentTensor(gem.Product(square, gem.Indexed(u, (j,))), (j,))
+
+    values = nodal_values(element, evaluation)
+    expected = numpy.einsum("...i,...i->...", values, values)[..., None] * values
+    assert numpy.allclose(nodal_values(element, cubed), expected)

--- a/test/gem/test_sum_factorise.py
+++ b/test/gem/test_sum_factorise.py
@@ -3,6 +3,8 @@ import pytest
 
 import gem
 from gem.interpreter import evaluate
+from gem import optimise
+from gem.node import traversal
 from gem.optimise import sum_factorise
 
 
@@ -50,3 +52,33 @@ def test_too_many_indices_in_one_contraction():
     table = gem.Indexed(gem.Literal(numpy.ones((2,) * 7)), indices)
     with pytest.raises(NotImplementedError):
         sum_factorise(indices, [table])
+
+
+def test_contraction_preserves_factorised_contractions():
+    # A dual evaluation contracts the weights with an expression whose
+    # coefficient evaluations are already sum factorised.  Those carry the
+    # point index of the contraction, so flattening them yields a single
+    # connected contraction that is too large to factorise.
+    numpy.random.seed(0)
+    p, q = gem.Index(extent=4), gem.Index(extent=4)
+    ijk = tuple(gem.Index(extent=3) for _ in range(3))
+
+    table = gem.Indexed(gem.Literal(numpy.random.rand(3, 3, 3, 4)), ijk + (p,))
+    dofs = numpy.random.rand(3, 3, 3)
+    evaluation = optimise.contraction(gem.IndexSum(gem.Product(table, gem.Indexed(gem.Literal(dofs), ijk)), ijk))
+    assert optimise.is_contraction(evaluation)
+
+    weights = numpy.random.rand(4, 4)
+    cubed = gem.Product(gem.Product(gem.Indexed(gem.Literal(weights), (q, p)), evaluation),
+                        gem.Product(evaluation, evaluation))
+    expression = gem.IndexSum(cubed, (p,))
+
+    with pytest.raises(NotImplementedError):
+        optimise.contraction(expression)
+
+    optimised = optimise.contraction(expression, stop_at=optimise.is_contraction)
+    assert evaluation in set(traversal([optimised]))
+
+    result, = evaluate([gem.ComponentTensor(optimised, (q,))])
+    expected = weights.dot(numpy.einsum("ijkp,ijk->p", numpy.asarray(table.children[0].array), dofs) ** 3)
+    assert numpy.allclose(result.arr, expected)

--- a/test/gem/test_sum_factorise.py
+++ b/test/gem/test_sum_factorise.py
@@ -1,3 +1,5 @@
+from itertools import chain, combinations
+
 import numpy
 import pytest
 
@@ -47,18 +49,25 @@ def test_independent_contractions(nfactors, ndims):
 
 
 def test_too_many_indices_in_one_contraction():
-    # A single connected contraction is still bounded.
+    # A connected contraction of more factors than the planner takes falls
+    # back on searching the orderings, which is still bounded.
     indices = tuple(gem.Index(extent=2) for _ in range(7))
-    table = gem.Indexed(gem.Literal(numpy.ones((2,) * 7)), indices)
+    factors = []
+    for extra in chain(combinations(indices[1:], 1), combinations(indices[1:], 2)):
+        shared = indices[:1] + extra
+        factors.append(gem.Indexed(gem.Literal(numpy.ones((2,) * len(shared))), shared))
+        if len(factors) > optimise._MAX_PLANNED_FACTORS:
+            break
+
     with pytest.raises(NotImplementedError):
-        sum_factorise(indices, [table])
+        sum_factorise(indices, factors)
 
 
-def test_contraction_preserves_factorised_contractions():
+def test_contraction_preserves_repeated_contractions():
     # A dual evaluation contracts the weights with an expression whose
-    # coefficient evaluations are already sum factorised.  Those carry the
-    # point index of the contraction, so flattening them yields a single
-    # connected contraction that is too large to factorise.
+    # coefficient evaluations are already sum factorised.  Flattening an
+    # evaluation renames its indices apart, so one used several times
+    # would be evaluated once per use.
     numpy.random.seed(0)
     p, q = gem.Index(extent=4), gem.Index(extent=4)
     ijk = tuple(gem.Index(extent=3) for _ in range(3))
@@ -73,12 +82,43 @@ def test_contraction_preserves_factorised_contractions():
                         gem.Product(evaluation, evaluation))
     expression = gem.IndexSum(cubed, (p,))
 
-    with pytest.raises(NotImplementedError):
-        optimise.contraction(expression)
-
-    optimised = optimise.contraction(expression, stop_at=optimise.is_contraction)
+    optimised = optimise.contraction(expression)
     assert evaluation in set(traversal([optimised]))
+
+    # The evaluation is contracted once and reused, so the result holds
+    # only that contraction and the one over the points
+    contractions = [node for node in traversal([optimised])
+                    if isinstance(node, gem.IndexSum)]
+    assert len(contractions) == 2
 
     result, = evaluate([gem.ComponentTensor(optimised, (q,))])
     expected = weights.dot(numpy.einsum("ijkp,ijk->p", numpy.asarray(table.children[0].array), dofs) ** 3)
     assert numpy.allclose(result.arr, expected)
+
+
+def test_contractions_joined_by_a_shared_index():
+    # A value index joins two coefficient evaluations into one connected
+    # contraction of more indices than an ordering search can take, but
+    # its product tree is planned by splitting the factors.
+    numpy.random.seed(0)
+    p = gem.Index(extent=4)
+    ijk = tuple(gem.Index(extent=3) for _ in range(3))
+    lmn = tuple(gem.Index(extent=3) for _ in range(3))
+
+    tables = [numpy.random.rand(3, 3, 3, 4) for _ in range(2)]
+    coefficients = [numpy.random.rand(3, 3, 3) for _ in range(2)]
+    factors = []
+    for indices, table, coefficient in zip((ijk, lmn), tables, coefficients):
+        factors.append(gem.Indexed(gem.Literal(table), indices + (p,)))
+        factors.append(gem.Indexed(gem.Literal(coefficient), indices))
+
+    sum_indices = ijk + lmn + (p,)
+    assert len(sum_indices) > 6
+
+    expression = sum_factorise(sum_indices, factors)
+    assert expression.free_indices == ()
+
+    result, = evaluate([expression])
+    evaluations = [numpy.einsum("ijkp,ijk->p", table, coefficient)
+                   for table, coefficient in zip(tables, coefficients)]
+    assert numpy.allclose(result.arr, evaluations[0].dot(evaluations[1]))

--- a/test/gem/test_sum_factorise.py
+++ b/test/gem/test_sum_factorise.py
@@ -1,0 +1,52 @@
+import numpy
+import pytest
+
+import gem
+from gem.interpreter import evaluate
+from gem.optimise import sum_factorise
+
+
+def contraction(nfactors, ndims, extent=2):
+    """Build a product of independent contractions.
+
+    Each factor contracts a table with a coefficient over its own indices,
+    as a tensor product coefficient evaluation does, so no factor carries
+    the indices of another.
+    """
+    numpy.random.seed(0)
+    sum_indices = []
+    factors = []
+    expected = 1.0
+    for _ in range(nfactors):
+        indices = tuple(gem.Index(extent=extent) for _ in range(ndims))
+        table = numpy.random.rand(*(extent,) * ndims)
+        coefficient = numpy.random.rand(*(extent,) * ndims)
+        factors.append(gem.Indexed(gem.Literal(table), indices))
+        factors.append(gem.Indexed(gem.Literal(coefficient), indices))
+        sum_indices.extend(indices)
+        expected *= numpy.sum(table * coefficient)
+    return tuple(sum_indices), factors, expected
+
+
+@pytest.mark.parametrize("nfactors,ndims", [(1, 3), (2, 3), (3, 3), (5, 3), (3, 5)])
+def test_independent_contractions(nfactors, ndims):
+    # Contractions that share no factor are independent, so they are
+    # factorised separately rather than by searching the orderings that
+    # interleave them.  Together they exceed what one exhaustive search
+    # can handle.
+    sum_indices, factors, expected = contraction(nfactors, ndims)
+    assert len(sum_indices) == nfactors * ndims
+
+    expression = sum_factorise(sum_indices, factors)
+    assert expression.free_indices == ()
+
+    result, = evaluate([expression])
+    assert numpy.allclose(result.arr, expected)
+
+
+def test_too_many_indices_in_one_contraction():
+    # A single connected contraction is still bounded.
+    indices = tuple(gem.Index(extent=2) for _ in range(7))
+    table = gem.Indexed(gem.Literal(numpy.ones((2,) * 7)), indices)
+    with pytest.raises(NotImplementedError):
+        sum_factorise(indices, [table])

--- a/test/gem/test_sum_factorise.py
+++ b/test/gem/test_sum_factorise.py
@@ -75,7 +75,7 @@ def test_contraction_preserves_repeated_contractions():
     table = gem.Indexed(gem.Literal(numpy.random.rand(3, 3, 3, 4)), ijk + (p,))
     dofs = numpy.random.rand(3, 3, 3)
     evaluation = optimise.contraction(gem.IndexSum(gem.Product(table, gem.Indexed(gem.Literal(dofs), ijk)), ijk))
-    assert optimise.is_contraction(evaluation)
+    assert isinstance(evaluation, gem.IndexSum)
 
     weights = numpy.random.rand(4, 4)
     cubed = gem.Product(gem.Product(gem.Indexed(gem.Literal(weights), (q, p)), evaluation),


### PR DESCRIPTION
Fixes #283 by recasting sum-factorization as a DP tree traversal with cost growing
with the number of factors as opposed to contraction indices, and falling back to
the original index combinatorial search when there are too many factors. 

TLDR: #280 kept an already factorised contraction whole by asking the caller to
pass `stop_at`. This PR drops that second pass and gets the same result from the
expression itself, by not flattening a contraction that is used more than once
and by planning the product tree instead of searching orderings of the indices.

## What changes

- **Flattening a contraction renames its indices apart.** That is what makes it
  sound, but it also means a coefficient evaluation used three times becomes
  three independent contractions, and is computed three times. So don't flatten
  a contraction that occurs more than once in the product. Expanding a product
  only pays where factorising the expanded form recovers the sharing that
  expansion broke, which multilinearity guarantees; a product of repeated
  evaluations is not multilinear in them, so there is nothing to recover.

- **Plan the product tree, not the index ordering.** Searching orderings has to
  multiply every factor carrying an index before it can reduce that index, so it
  can never reduce over part of a product and multiply the rest in afterwards.
  Build the tree by dynamic programming over subsets of the factors, reducing
  each index at the smallest subtree that holds every factor carrying it. That
  costs `3^factors` rather than `indices!`, and plans the contractions that a
  tensor value index joins together.

- With the tree planned, dual evaluation no longer needs the inner
  `sum_factorise`, so only one `gem.optimise.contraction` remains, and the bound
  on the ordering search stays where it was.

- Recognising a repeated contraction from the expression retires the `stop_at`
  argument of `contraction` and the `is_contraction` predicate #280 added for it,
  which nothing passes any more. `traverse_product` and `traverse_sum` keep their
  own `stop_at`, which `gem.refactorise` still uses.

## Interpolation on a hexahedron

Kernel flop counts and temporaries, as `count / entries / largest`.

| interpolate | flops main | flops PR | temporaries main | temporaries PR | compile main | compile PR |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `f*f*f`, CG1 → CG1 | 96 | 96 | 9 / 11 / 2 | 9 / 13 / 2 | 0.011 s | 0.011 s |
| `f*f*f*f`, CG1 → CG1 | 104 | 104 | 9 / 11 / 2 | 9 / 13 / 2 | 0.011 s | 0.011 s |
| `f*f`, CG4 → DG3 | 2568 | 2568 | 4 / 51 / 25 | 4 / 66 / 25 | 0.008 s | 0.009 s |
| `dot(u, u)*u`, vector CG4 → vector CG4 | 23875 | 23875 | 14 / 210 / 75 | 14 / 270 / 75 | 0.017 s | 0.018 s |
| `dot(A, A)`, tensor CG2 → tensor CG3 | 16776 | 16776 | 81 / 240 / 4 | 81 / 240 / 4 | 0.089 s | 0.163 s |
| `inner(A, A)`, tensor CG2 → CG2 | 4131 | 4131 | 120 / 126 / 3 | 120 / 180 / 3 | 0.126 s | 0.129 s |
| `grad(f)[0]`, CG4 → CG4 | 14106 | **13981** | 92 / 292 / 25 | 91 / 375 / 25 | 0.066 s | 0.066 s |
| `div(u)`, vector CG4 → DG3 | 23548 | **23100** | 110 / 391 / 25 | 109 / 543 / 25 | 0.080 s | 0.077 s |

Every case that raised `NotImplementedError: Too many indices for sum
factorisation!` on the base of #280 still compiles here.

`dot(A, A)` costs 0.078 s more to compile. It is the one case here whose value
index joins the evaluations into a contraction of seven indices, so it is the
one case that reaches the planner with enough factors to plan.

## Helmholtz on an extruded hexahedral mesh

`inner(u, v)*dx + inner(d(u), d(v))*dx`, with `d` = `grad` for CG and `curl` for
NCE. This is the cost of the planner where nothing needed fixing.

| | flops main | flops PR | entries main | entries PR | compile main | compile PR |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| CG1 | 14732 | 14732 | 1153 | 1171 | 0.120 s | 0.126 s |
| CG3 | 611668 | 611668 | 4460 | 4502 | 0.105 s | 0.103 s |
| CG7 | 37651332 | 37651332 | 90392 | 90482 | 0.101 s | 0.104 s |
| NCE1 | 136618 | 136651 | 7151 | 7178 | 1.028 s | 1.003 s |
| NCE3 | 4486030 | 4486063 | 22058 | 22109 | 0.754 s | 0.758 s |
| NCE7 | 282933862 | 282933895 | 612438 | 612537 | 0.752 s | 0.755 s |

Compile time here is within run to run variation either way. The NCE forms cost
33 flops more at every degree. The planner finds cheaper
trees for three subproblems of those forms, 70 against 90 operations each, but costs
each connected subproblem on its own while the subproblems share terms, so the
cheaper trees drop a shared subexpression. Keeping the whole expression in view
when costing a plan is left for later.

## Tests

`test_sum_factorise.py` covers the bound, now on the ordering search the planner
falls back on; an unrestricted contraction keeping a repeated evaluation whole;
and a contraction joined by a value index into more indices than an ordering
search can take. Each was checked to fail when the change it covers is reverted.

AI declaration: written with Claude Code (Claude Opus 5).

