### PR TITLE
Preserve finite element linear maps during factorisation

### DIFF
--- a/gem/coffee.py
+++ b/gem/coffee.py
@@ -4,14 +4,17 @@ algorithm operating on a GEM representation.
 This file is NOT for code generation as a COFFEE AST.
 """
 
+from collections import defaultdict
 from itertools import chain, repeat
 import logging
 
 import numpy
 
-from gem.gem import IndexSum, one
-from gem.optimise import make_sum, make_product
-from gem.refactorise import Monomial
+from gem.gem import ComponentTensor, Index, Indexed, IndexSum, one
+from gem.node import MemoizerArg
+from gem.optimise import (filtered_replace_indices, has_arithmetic,
+                          make_sum, make_product)
+from gem.refactorise import Monomial, MonomialSum
 from gem.utils import groupby
 
 
@@ -197,6 +200,74 @@ def factorise_atomics(monomials, optimal_atomics, linear_indices):
     return new_monomials
 
 
+def _share_linear_maps(
+        monomial_sum: MonomialSum,
+        linear_indices: tuple[Index, ...]) -> MonomialSum:
+    """Share isomorphic maps of distinct multilinear axes.
+
+    Parameters
+    ----------
+    monomial_sum
+        Sum-of-products representation of a multilinear expression.
+    linear_indices
+        Free indices identifying argument axes.
+
+    Returns
+    -------
+    MonomialSum
+        Representation whose repeated linear maps access one tensor.
+
+    Notes
+    -----
+    Test and trial axes use distinct indices even when they apply the same
+    finite element map.  Renaming each axis to a canonical index exposes
+    that isomorphism without inspecting the element family.  Materialising
+    the canonical map is generalised code motion: the basis transformation
+    is evaluated once and both axes index its result.
+
+    """
+    linear_indices = tuple(linear_indices)
+    linear_set = frozenset(linear_indices)
+    canonical = {
+        index.extent: Index(extent=index.extent)
+        for index in linear_indices
+    }
+    replacer = MemoizerArg(filtered_replace_indices)
+    groups = defaultdict(list)
+    for monomial in monomial_sum:
+        for atomic in monomial.atomics:
+            involved = linear_set.intersection(atomic.free_indices)
+            if len(involved) != 1:
+                continue
+            index, = involved
+            normal = replacer(atomic, ((index, canonical[index.extent]),))
+            groups[normal].append((atomic, index))
+
+    replacements = {}
+    for normal, occurrences in groups.items():
+        indices = {index for _, index in occurrences}
+        if len(indices) < 2 or not has_arithmetic((normal,)):
+            continue
+        index = canonical[next(iter(indices)).extent]
+        tensor = ComponentTensor(normal, (index,))
+        replacements.update(
+            (atomic, Indexed(tensor, (original,)))
+            for atomic, original in occurrences)
+
+    if not replacements:
+        return monomial_sum
+
+    result = MonomialSum()
+    for monomial in monomial_sum:
+        result.add(
+            monomial.sum_indices,
+            tuple(replacements.get(atomic, atomic)
+                  for atomic in monomial.atomics),
+            monomial.rest,
+        )
+    return result
+
+
 def optimise_monomial_sum(monomial_sum, linear_indices):
     """Choose optimal common atomic subexpressions and factorise a
     :class:`MonomialSum` object to create a GEM expression.
@@ -206,6 +277,7 @@ def optimise_monomial_sum(monomial_sum, linear_indices):
 
     :returns: factorised GEM expression
     """
+    monomial_sum = _share_linear_maps(monomial_sum, linear_indices)
     groups = groupby(monomial_sum, key=lambda m: frozenset(m.sum_indices))
     new_monomials = []
     for _, monomials in groups:

--- a/gem/flop_count.py
+++ b/gem/flop_count.py
@@ -5,6 +5,7 @@ total number of floating point operations for a given script.
 
 import gem.gem as gem
 import gem.impero as imp
+from contextvars import ContextVar
 from functools import singledispatch
 import numpy
 import math
@@ -26,7 +27,11 @@ def statement_for(tree, temporaries):
     extent = tree.index.extent
     assert extent is not None
     child, = tree.children
-    flops = statement(child, temporaries)
+    token = _active_indices.set(_active_indices.get() | {tree.index})
+    try:
+        flops = statement(child, temporaries)
+    finally:
+        _active_indices.reset(token)
     return flops * extent
 
 
@@ -168,7 +173,14 @@ def flops_solve(expr, temporaries):
 
 @flops.register(gem.ComponentTensor)
 def flops_componenttensor(expr, temporaries):
-    raise ValueError("Not expecting ComponentTensor")
+    body, = expr.children
+    # Scheduling emits an assignment over the indices that no enclosing For
+    # already iterates.  Count those extents here; the loops that carry the
+    # rest count them.
+    implicit = tuple(index for index in expr.multiindex
+                     if index not in _active_indices.get())
+    extent = numpy.prod([index.extent for index in implicit], dtype=int)
+    return extent * expression_flops(body, temporaries)
 
 
 def expression_flops(expression, temporaries, top=False):
@@ -192,6 +204,14 @@ def count_flops(impero_c):
     :returns: approximate flop count for the tree.
     """
     try:
-        return statement(impero_c.tree, set(impero_c.temporaries))
+        token = _active_indices.set(frozenset())
+        try:
+            return statement(impero_c.tree, set(impero_c.temporaries))
+        finally:
+            _active_indices.reset(token)
     except (ValueError, NotImplementedError):
         return 0
+
+
+_active_indices = ContextVar("flop_count_active_indices",
+                             default=frozenset())

--- a/gem/gem.py
+++ b/gem/gem.py
@@ -311,10 +311,13 @@ class Literal(Constant):
             return False
         if self.shape != other.shape:
             return False
+        if self.dtype != other.dtype:
+            return False
         return numpy.array_equal(self.array, other.array)
 
     def get_hash(self):
-        return hash((type(self), self.shape, tuple(self.array.flat)))
+        return hash((type(self), self.shape, self.dtype,
+                     tuple(self.array.flat)))
 
     @property
     def value(self):

--- a/gem/optimise.py
+++ b/gem/optimise.py
@@ -1,7 +1,9 @@
 """A set of routines implementing various transformations on GEM
 expressions."""
 
+import math
 from collections import Counter, OrderedDict, defaultdict
+from collections.abc import Callable, Iterable
 from functools import singledispatch, partial
 from itertools import combinations, permutations, zip_longest
 from numbers import Integral
@@ -15,6 +17,7 @@ from gem.gem import (Node, Failure, Identity, Constant, Literal, Zero,
                      Product, Sum, Comparison, Conditional, Division,
                      Index, VariableIndex, Indexed, FlexiblyIndexed,
                      IndexSum, ComponentTensor, ListTensor, Delta,
+                     MathFunction, MinValue, MaxValue, Power, Inverse, Solve,
                      partial_indexed, one)
 
 
@@ -732,6 +735,274 @@ def traverse_sum(expression, stop_at=None):
         else:
             result.append(expr)
     return result
+
+
+def _iteration_count(indices: Iterable[Index]) -> int:
+    """Count the points of a rectangular iteration space.
+
+    Parameters
+    ----------
+    indices
+        Indices an operation depends on.
+
+    Returns
+    -------
+    int
+        Number of executions of the operation.
+
+    """
+    return int(numpy.prod([index.extent for index in indices], dtype=int))
+
+
+def _operation_count(node: Node) -> int:
+    """Estimate the scalar operations performed by one GEM node.
+
+    Parameters
+    ----------
+    node
+        Scalar expression node.
+
+    Returns
+    -------
+    int
+        Operations over the node's complete iteration domain.
+
+    Notes
+    -----
+    Negation folds into the operation that consumes it, so a product with
+    ``-1`` costs nothing.
+
+    """
+    domain = _iteration_count(node.free_indices)
+    if isinstance(node, Product):
+        if any(isinstance(child, Literal) and not child.shape
+               and child.value == -1 for child in node.children):
+            return 0
+        return domain
+    if isinstance(node, (Sum, Division, MathFunction, MinValue, MaxValue)):
+        return domain
+    if isinstance(node, Power):
+        _, exponent = node.children
+        if isinstance(exponent, Literal) and not exponent.shape:
+            value = exponent.value
+            if value > 0 and value == math.floor(value):
+                return math.ceil(math.log2(value)) * domain
+        return 5 * domain
+    if isinstance(node, IndexSum):
+        body, = node.children
+        return _iteration_count(body.free_indices)
+    if isinstance(node, Inverse):
+        n, _ = node.shape
+        return 2 * n ** 3
+    if isinstance(node, Solve):
+        n, m = node.shape
+        return 2 * n * m + 2 * n ** 3
+    return 0
+
+
+def has_arithmetic(expressions: Iterable[Node]) -> bool:
+    """Does a GEM DAG perform any scalar arithmetic?
+
+    Parameters
+    ----------
+    expressions
+        Roots of a scalar GEM expression DAG.
+
+    Returns
+    -------
+    bool
+        Whether any node costs arithmetic to evaluate.
+
+    Notes
+    -----
+    Materialising a tabulation reference buys no arithmetic, so sharing one
+    only adds storage.
+
+    """
+    return any(map(_operation_count, traversal(tuple(expressions))))
+
+
+def estimate_cost(expressions: Iterable[Node]) -> tuple[int, int, int, int]:
+    """Estimate arithmetic work and contraction storage for a GEM DAG.
+
+    Each structurally shared operation counts once over the domain its free
+    indices induce.  An :class:`~gem.gem.IndexSum` contributes one
+    accumulation per point of its body domain.  Storage counts the result
+    domains of contractions, the intermediates that scheduling exposes.
+
+    Parameters
+    ----------
+    expressions
+        Roots of a scalar GEM expression DAG.
+
+    Returns
+    -------
+    tuple of int
+        Operation count, total contraction storage, largest contraction, and
+        expression-node count.  Comparing the tuples lexicographically ranks
+        arithmetic first and breaks ties by storage.
+
+    """
+    nodes = tuple(traversal(tuple(expressions)))
+    sizes = [_iteration_count(node.free_indices)
+             for node in nodes if isinstance(node, IndexSum)]
+    return (sum(map(_operation_count, nodes)),
+            sum(sizes),
+            max(sizes, default=0),
+            len(nodes))
+
+
+def _distribute_sum(expr: Node, predicate: Callable[[Node], bool]) -> list[Node]:
+    """Distribute selected sums through products and contractions.
+
+    Parameters
+    ----------
+    expr
+        GEM expression to distribute.
+    predicate
+        Predicate selecting the operations to distribute.
+
+    Returns
+    -------
+    list of Node
+        Additive terms after distribution.
+
+    Notes
+    -----
+    Memoization uses object identity.  Structurally equal GEM nodes can have
+    deep expression trees, while distribution only needs to reuse actual DAG
+    nodes.
+
+    """
+    results = {}
+    active = {}
+    stack = [(expr, False)]
+    while stack:
+        node, expanded = stack.pop()
+        key = id(node)
+        if key in results:
+            continue
+        if not expanded:
+            stack.append((node, True))
+            stack.extend((c, False) for c in node.children)
+            continue
+        active[key] = predicate(node) or any(
+            active[id(child)] for child in node.children)
+        if active[key] and isinstance(node, (Sum, IndexSum, Product)):
+            if isinstance(node, Sum):
+                results[key] = [
+                    term
+                    for child in node.children
+                    for term in results[id(child)]]
+            elif isinstance(node, IndexSum):
+                body, = node.children
+                results[key] = [
+                    IndexSum(term, tuple(
+                        index for index in node.multiindex
+                        if index in term.free_indices))
+                    for term in results[id(body)]]
+            else:  # Product
+                a, b = node.children
+                ta, tb = results[id(a)], results[id(b)]
+                results[key] = [node] if len(ta) == 1 and len(tb) == 1 \
+                    else [Product(x, y) for x in ta for y in tb]
+        else:
+            results[key] = [node]
+    return results[id(expr)]
+
+
+def _is_linear_map(node: Node, linear_indices: frozenset) -> bool:
+    """Is a node a linear map into one multilinear axis?
+
+    Parameters
+    ----------
+    node
+        GEM expression node.
+    linear_indices
+        Free indices identifying the multilinear axes.
+
+    Returns
+    -------
+    bool
+        Whether the node is a sum over exactly one such axis.
+
+    """
+    return (isinstance(node, Sum)
+            and len(linear_indices.intersection(node.free_indices)) == 1)
+
+
+def has_linear_maps(
+        expressions: Iterable[Node],
+        linear_indices: Iterable[Index]) -> bool:
+    """Does a GEM DAG contain a finite element linear map?
+
+    Parameters
+    ----------
+    expressions
+        Roots of a multilinear GEM expression DAG.
+    linear_indices
+        Free indices identifying the multilinear axes.
+
+    Returns
+    -------
+    bool
+        Whether preserving one-axis sums can change the factorisation.
+
+    Notes
+    -----
+    Answering this costs one traversal, where building the preserved
+    factorisation to compare it costs a whole pass of monomial collection.
+
+    """
+    linear_indices = frozenset(linear_indices)
+    return any(_is_linear_map(node, linear_indices)
+               for node in traversal(tuple(expressions)))
+
+
+def preserve_linear_maps(
+        expression: Node,
+        linear_indices: Iterable[Index]) -> tuple[
+            tuple[Node, ...], tuple[Node, ...]]:
+    """Expose multilinear terms and retain each one-axis linear map.
+
+    A sum that depends on one linear index represents a linear map into an
+    argument tabulation. A sum that depends on several linear indices
+    separates multilinear form terms. This function distributes the latter
+    sums and returns the former sums as factors.
+
+    Parameters
+    ----------
+    expression
+        Multilinear GEM expression.
+    linear_indices
+        Free indices identifying the linear axes.
+
+    Returns
+    -------
+    tuple
+        Additive terms and the linear-map factors that they contain.
+
+    """
+    linear_indices = frozenset(linear_indices)
+
+    def multilinear_sum(node: Node) -> bool:
+        return isinstance(node, Sum) and len(
+            linear_indices.intersection(node.free_indices)) > 1
+
+    if not has_linear_maps((expression,), linear_indices):
+        return (expression,), ()
+
+    terms = tuple(_distribute_sum(expression, multilinear_sum))
+    groups = OrderedDict()
+    for term in terms:
+        _, factors = traverse_product(term)
+        for factor in factors:
+            if _is_linear_map(factor, linear_indices):
+                groups.setdefault(factor)
+
+    if not groups:
+        return (expression,), ()
+    return terms, tuple(groups)
 
 
 def repeated_contractions(expression):

--- a/gem/refactorise.py
+++ b/gem/refactorise.py
@@ -2,16 +2,17 @@
 refactorisation."""
 
 from collections import Counter, OrderedDict, defaultdict, namedtuple
+from collections.abc import Callable, Iterable
 from functools import singledispatch
 from itertools import product
 from sys import intern
 
 from gem.node import Memoizer, traversal
-from gem.gem import (Node, Conditional, Zero, Product, Sum, Indexed,
+from gem.gem import (Node, Conditional, Index, Zero, Product, Sum, Indexed,
                      ListTensor, one, MathFunction)
-from gem.optimise import (remove_componenttensors, sum_factorise,
-                          traverse_product, traverse_sum, unroll_indexsum,
-                          make_rename_map, make_renamer)
+from gem.optimise import (preserve_linear_maps, remove_componenttensors,
+                          sum_factorise, traverse_product, traverse_sum,
+                          unroll_indexsum, make_rename_map, make_renamer)
 
 
 # Refactorisation labels
@@ -266,23 +267,36 @@ def _collect_monomials_conditional(expression, self):
     return result
 
 
-def collect_monomials(expressions, classifier):
-    """Refactorises expressions into a sum-of-products form, using
-    distributivity rules (i.e. a*(b + c) -> a*b + a*c).  Expansion
-    proceeds until all "compound" expressions are broken up.
+def _collect_monomial_sums(
+        expressions: Iterable[Node],
+        classifier: Callable[[Node], str]) -> list[MonomialSum]:
+    """Collect monomial sums using the supplied node classifier.
 
-    :arg expressions: GEM expressions to refactorise
-    :arg classifier: a function that can classify any GEM expression
-                     as ``ATOMIC``, ``COMPOUND``, or ``OTHER``.  This
-                     classification drives the factorisation.
+    Parameters
+    ----------
+    expressions : iterable of Node
+        GEM expressions to refactorise.
+    classifier : callable
+        Function labelling each node as ``ATOMIC``, ``COMPOUND``, or
+        ``OTHER``.
 
-    :returns: list of :py:class:`MonomialSum`s
+    Returns
+    -------
+    list of MonomialSum
+        Polynomial representations of the expressions.
 
-    :raises FactorisationError: Failed to break up some "compound"
-                                expressions with expansion.
+    Raises
+    ------
+    FactorisationError
+        If a compound expression cannot be expanded.
+
+    Notes
+    -----
+    ``expressions`` must already have had its ComponentTensors removed, so
+    that a caller identifying nodes to classify sees the nodes this
+    collector will visit.
+
     """
-    # Get ComponentTensors out of the way
-    expressions = remove_componenttensors(expressions)
 
     # Get ListTensors out of the way
     must_unroll = []  # indices to unroll
@@ -302,3 +316,64 @@ def collect_monomials(expressions, classifier):
     mapper.classifier = classifier
     mapper.rename_map = make_rename_map()
     return list(map(mapper, expressions))
+
+
+def collect_monomials(
+        expressions: Iterable[Node],
+        classifier: Callable[[Node], str],
+        linear_indices: Iterable[Index] = ()) -> list[MonomialSum]:
+    """Collect structure-preserving sum-of-products representations.
+
+    Parameters
+    ----------
+    expressions
+        GEM expressions to refactorise.
+    classifier
+        Function that labels GEM nodes for polynomial collection.
+    linear_indices
+        Free indices identifying the multilinear axes.  Sums depending on
+        exactly one such axis represent linear maps and remain atomic.
+
+    Returns
+    -------
+    list of MonomialSum
+        One polynomial representation for each input expression.
+
+    Notes
+    -----
+    A one-axis sum is a finite element linear operand: examples include a
+    sparse basis transformation and a tensor-product tabulation factor.
+    Preserving it keeps domain-specific basis structure available for
+    contraction optimisation.  This does not make the map opaque: its GEM
+    expression remains available for scalar simplification and code motion.
+
+    Sums involving several linear axes separate form monomials and are
+    distributed.  COFFEE subsequently chooses scalar factorisations across
+    the resulting operands.  Keeping these two stages distinct avoids a
+    Cartesian expansion of basis-map entries before loop placement.
+
+    """
+    # Remove ComponentTensors here, not in the collector.  Removing them
+    # rebuilds nodes, and the maps found below must be the very nodes that
+    # the collector classifies.
+    expressions = remove_componenttensors(tuple(expressions))
+    linear_indices = tuple(linear_indices)
+    if not linear_indices:
+        return _collect_monomial_sums(expressions, classifier)
+
+    result = []
+    for expression in expressions:
+        terms, linear_maps = preserve_linear_maps(expression, linear_indices)
+        if not linear_maps:
+            monomial_sum, = _collect_monomial_sums((expression,), classifier)
+            result.append(monomial_sum)
+            continue
+
+        map_ids = frozenset(map(id, linear_maps))
+
+        def preserve_map(node: Node, map_ids=map_ids) -> str:
+            return ATOMIC if id(node) in map_ids else classifier(node)
+
+        result.append(MonomialSum.sum(
+            *_collect_monomial_sums(terms, preserve_map)))
+    return result

--- a/test/gem/test_sum_factorise.py
+++ b/test/gem/test_sum_factorise.py
@@ -1,3 +1,4 @@
+from functools import partial, reduce
 from itertools import chain, combinations
 
 import numpy
@@ -8,6 +9,9 @@ from gem.interpreter import evaluate
 from gem import optimise
 from gem.node import traversal
 from gem.optimise import sum_factorise
+from gem.coffee import optimise_monomial_sum
+from gem.refactorise import (ATOMIC, COMPOUND, OTHER,
+                             collect_monomials)
 
 
 def contraction(nfactors, ndims, extent=2):
@@ -122,3 +126,99 @@ def test_contractions_joined_by_a_shared_index():
     evaluations = [numpy.einsum("ijkp,ijk->p", table, coefficient)
                    for table, coefficient in zip(tables, coefficients)]
     assert numpy.allclose(result.arr, evaluations[0].dot(evaluations[1]))
+
+
+def laplacian(ndofs=4, ndims=2):
+    """Build a Laplacian element tensor from a mapped gradient table.
+
+    The physical gradient of each basis function is the reference gradient
+    mapped by the inverse Jacobian.  Test and trial functions apply the same
+    map, over their own argument index.
+    """
+    numpy.random.seed(0)
+    i = gem.Index(extent=ndofs)
+    j = gem.Index(extent=ndofs)
+    k = gem.Index(extent=ndims)
+    reference = gem.Literal(numpy.random.rand(ndofs, ndims))
+    jacobian = gem.Literal(numpy.random.rand(ndims, ndims))
+
+    def gradient(argument):
+        # The pullback is a contraction over the topological dimension,
+        # which reaches factorisation already unrolled into a sum.
+        return reduce(gem.Sum, [
+            gem.Product(gem.Indexed(reference, (argument, l)),
+                        gem.Indexed(jacobian, (l, k)))
+            for l in range(ndims)])
+
+    expression = gem.IndexSum(
+        gem.Product(gradient(i), gradient(j)), (k,))
+    expected = numpy.einsum(
+        "il,lk,jm,mk->ij", reference.array, jacobian.array,
+        reference.array, jacobian.array)
+    return (i, j), expression, expected
+
+
+def monomial_sum(linear_indices):
+    """Collect the Laplacian into monomials, with or without preservation."""
+    arguments, expression, expected = laplacian()
+    classifier = partial(_classify, frozenset(arguments))
+    result, = collect_monomials(
+        [expression], classifier,
+        arguments if linear_indices else ())
+    return arguments, result, expected
+
+
+def _classify(arguments, expression):
+    shared = arguments.intersection(expression.free_indices)
+    if not shared:
+        return OTHER
+    if len(shared) == 1 and isinstance(expression, gem.Indexed):
+        return ATOMIC
+    return COMPOUND
+
+
+def test_linear_map_is_preserved():
+    # Distributing the map expands it into the product of its entries, so
+    # preserving it leaves strictly fewer monomials to factorise.
+    _, preserved, _ = monomial_sum(linear_indices=True)
+    _, expanded, _ = monomial_sum(linear_indices=False)
+    assert len(list(preserved)) < len(list(expanded))
+    assert len(list(preserved)) == 1
+
+
+def test_preserved_linear_map_is_shared():
+    # Test and trial apply the same map over different indices.  COFFEE
+    # materialises it once, so one tensor carries both.
+    arguments, preserved, expected = monomial_sum(linear_indices=True)
+    expression = optimise_monomial_sum(preserved, arguments)
+    tensors = [node for node in traversal((expression,))
+               if isinstance(node, gem.ComponentTensor)]
+    assert len(tensors) == 1
+
+    i, j = arguments
+    result, = evaluate([gem.ComponentTensor(expression, (i, j))])
+    assert numpy.allclose(result.arr, expected)
+
+
+def test_expanded_and_preserved_agree():
+    arguments, expanded, expected = monomial_sum(linear_indices=False)
+    expression = optimise_monomial_sum(expanded, arguments)
+    result, = evaluate([gem.ComponentTensor(expression, arguments)])
+    assert numpy.allclose(result.arr, expected)
+
+
+def test_has_linear_maps_detects_preservable_maps():
+    arguments, expression, _ = laplacian()
+    assert optimise.has_linear_maps([expression], arguments)
+    # With no argument axis declared, nothing is a linear map.
+    assert not optimise.has_linear_maps([expression], ())
+
+
+def test_estimate_cost_counts_the_contraction():
+    _, expression, _ = laplacian(ndofs=4, ndims=2)
+    flops, storage, largest, nodes = optimise.estimate_cost([expression])
+    # Two mapped gradients over (argument, k, l) and their contraction
+    # over k, all counted over their own domains.
+    assert flops > 0
+    assert storage >= largest > 0
+    assert nodes > 0


### PR DESCRIPTION
Goal: to inject finite element structure down to the C level.

Generate code that separates the pullbacks from the quadrature loop.

Stacked on #282. Needs firedrakeproject/firedrake#5362 to pass the argument
indices; without it everything here is inert, which the baseline below relies on.

## What changes

- **A pullback reaches TSFC as a sum over one argument axis**: the physical
  gradient, divergence or curl of one basis function. Monomial collection
  distributed over that sum, so the geometry was pushed through the middle of
  the element tensor contraction and each argument axis mapped its own
  tabulation. `collect_monomials` now takes the argument axes, distributes only
  the sums spanning several of them, which separate form monomials, and keeps
  the one-axis sums atomic.

- **COFFEE renames each argument axis to a canonical index.** That exposes that
  test and trial apply the same map without inspecting the element family, and
  materialises the map once. This is generalised code motion: the basis
  transformation is evaluated once and both axes index its result.

- **Removing `ComponentTensor`s happens in `collect_monomials`**, not inside the
  collector. The collector rebuilds nodes, and the maps identified here have to
  be the very nodes it then classifies.

- **`estimate_cost` gives a caller a cost for a whole GEM DAG**, so preserving a
  map is compared against expanding it rather than assumed better.
  `has_linear_maps` answers whether the comparison is worth making, for one
  traversal instead of a whole collection pass.

- **`flop_count` counts a preserved map.** It reaches scheduling as a
  `ComponentTensor` assignment rather than a loop nest, so the multiindex
  extents that no enclosing `For` supplies are counted here. It previously
  raised `ValueError`, and `count_flops` turned that into a silent zero.

- **`Literal` compared and hashed without its dtype**, so tables holding the same
  numbers at different dtypes were interchangeable wherever GEM memoizes on node
  identity, which the map sharing above relies on.

## Benchmarks

Re-run against `main` for every case below. The bilinear form is
`inner(u, v)*dx + inner(d(u), d(v))*dx1`, with `d` = `grad` for CG and Q,
`div` for RT, and `curl` for NCE, `dx1` forcing a separate quadrature degree
for the derivative term, on simplices and on an extruded quadrilateral mesh.
`tsfc (s)` is the TSFC compile time; `build (s)` is the isolated cold-cache C
build (compiler and linker only, no TSFC, no PyOP2); `kernel (s)` is the
isolated per-call kernel time: the compiled kernel is called directly,
bypassing PyOP2's Python wrapper and the local-to-global indirection, and
averaged over calls made in one second. `array temps`/`entries`/`largest`
count mutable loopy temporaries with a shape, their total entries, and the
largest single temporary. `main` is measured against the real, unpatched
firedrake, since it cannot import a tsfc that expects the gem API this PR
adds; the PR side is measured against the firedrake commit that adds exactly
that API (`0bf4a4007`).

### Bilinear form

| element | degree | dim | flops | array temps | entries | largest | AST lines | tsfc (s) | build (s) | kernel (s) |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| CG | 1 | 2 | 159 -> 149 | 3 | 15 | 9 | 95 -> 96 | 0.033 -> 0.034 | 0.57 -> 0.56 | 0.000002 -> 0.000002 |
| CG | 3 | 2 | 5,547 | 4 | 220 | 100 | 116 | 0.034 -> 0.038 | 0.62 -> 0.66 | 0.000012 -> 0.000012 |
| CG | 5 | 2 | 53,827 | 4 | 924 | 441 | 116 | 0.037 -> 0.038 | 0.67 -> 0.68 | 0.000062 -> 0.000062 |
| CG | 1 | 3 | 429 -> 387 | 4 | 28 | 16 | 138 -> 135 | 0.057 -> 0.058 | 0.71 -> 0.68 | 0.000013 -> 0.000013 |
| CG | 3 | 3 | 49,592 | 5 | 860 | 400 | 169 | 0.061 -> 0.067 | 0.85 -> 0.83 | 0.000515 -> 0.000513 |
| CG | 5 | 3 | 1,340,021 | 5 | 6,440 | 3,136 | 169 | 0.064 -> 0.074 | 1.35 -> 1.33 | 0.005147 -> 0.005143 |
| RT | 1 | 2 | 259 -> 232 | 4 | 18 | 9 | 107 -> 103 | 0.041 -> 0.044 | 0.60 -> 0.58 | 0.000003 -> 0.000003 |
| RT | 3 | 2 | 18,098 -> 15,608 | 5 | 495 | 225 | 122 -> 118 | 0.045 -> 0.045 | 0.68 -> 0.65 | 0.000023 -> 0.000023 |
| RT | 5 | 2 | 210,463 -> 172,341 | 5 | 2,555 | 1,225 | 122 -> 118 | 0.045 -> 0.046 | 0.77 -> 0.76 | 0.000149 -> 0.000147 |
| RT | 1 | 3 | 852 -> 773 | 6 -> 5 | 36 -> 32 | 16 | 158 -> 134 | 0.060 -> 0.061 | 0.75 -> 0.68 | 0.000015 -> 0.000016 |
| RT | 3 | 3 | 281,708 -> 226,124 | 6 | 2,736 | 1,296 | 168 -> 150 | 0.068 -> 0.068 | 0.97 -> 0.92 | 0.000873 -> 0.000906 |
| RT | 5 | 3 | 10,384,508 -> 7,865,477 | 6 | 29,280 | 14,400 | 168 -> 150 | 0.097 -> 0.096 | 2.72 -> 2.65 | 0.020563 -> 0.020164 |
| Q | 1 | 3 | 7,774 | 55 -> 61 | 690 -> 708 | 64 | 684 -> 687 | 0.159 -> 0.165 | 2.19 -> 2.23 | 0.000015 -> 0.000014 |
| Q | 5 | 3 | 2,679,657 | 31 -> 37 | 23,149 -> 23,191 | 7,776 | 394 | 0.128 -> 0.133 | 1.62 -> 1.61 | 0.005725 -> 0.005670 |
| Q | 7 | 3 | 16,034,499 | 31 -> 37 | 87,199 -> 87,253 | 32,768 | 394 | 0.127 -> 0.131 | 1.90 -> 1.84 | 0.044677 -> 0.044074 |
| NCE | 1 | 3 | 66,447 -> 66,480 | 546 -> 552 | 4,375 -> 4,393 | 27 | 3,235 -> 3,253 | 1.077 -> 1.128 | 13.39 -> 13.15 | 0.000085 -> 0.000086 |
| NCE | 5 | 3 | 18,459,460 -> 18,459,493 | 239 -> 245 | 146,181 -> 146,223 | 6,480 | 1,962 -> 1,980 | 0.885 -> 0.892 | 8.16 -> 8.03 | 0.048325 -> 0.047772 |
| NCE | 7 | 3 | 115,963,956 -> 115,963,989 | 239 -> 245 | 604,385 -> 604,439 | 28,672 | 1,962 -> 1,980 | 0.833 -> 0.891 | 10.25 -> 10.23 | 0.452663 -> 0.444416 |

### Matrix-free action

| element | degree | dim | flops | array temps | entries | largest | AST lines | tsfc (s) | build (s) | kernel (s) |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| CG | 1 | 2 | 84 | 1 | 3 | 3 | 88 | 0.033 -> 0.035 | 0.55 -> 0.57 | 0.000001 -> 0.000001 |
| CG | 3 | 2 | 1,107 | 2 | 20 | 10 | 107 | 0.035 -> 0.036 | 0.61 -> 0.61 | 0.000002 -> 0.000002 |
| CG | 5 | 2 | 5,133 | 2 | 42 | 21 | 107 | 0.036 -> 0.038 | 0.66 -> 0.67 | 0.000008 -> 0.000008 |
| CG | 1 | 3 | 191 | 1 | 4 | 4 | 129 | 0.056 -> 0.055 | 0.70 -> 0.69 | 0.000003 -> 0.000003 |
| CG | 3 | 3 | 4,994 | 2 | 40 | 20 | 145 | 0.055 -> 0.059 | 0.76 -> 0.78 | 0.000027 -> 0.000027 |
| CG | 5 | 3 | 47,954 | 2 | 112 | 56 | 145 | 0.057 -> 0.062 | 1.23 -> 1.23 | 0.000284 -> 0.000280 |
| RT | 1 | 2 | 151 | 1 | 3 | 3 | 92 | 0.042 -> 0.045 | 0.57 -> 0.59 | 0.000001 -> 0.000001 |
| RT | 3 | 2 | 2,413 | 2 | 30 | 15 | 111 | 0.042 -> 0.044 | 0.65 -> 0.64 | 0.000004 -> 0.000004 |
| RT | 5 | 2 | 12,018 | 2 | 70 | 35 | 111 | 0.043 -> 0.044 | 0.77 -> 0.75 | 0.000021 -> 0.000021 |
| RT | 1 | 3 | 405 | 1 | 4 | 4 | 132 | 0.055 -> 0.060 | 0.68 -> 0.67 | 0.000004 -> 0.000004 |
| RT | 3 | 3 | 15,642 | 2 | 72 | 36 | 145 | 0.061 -> 0.066 | 0.89 -> 0.92 | 0.000085 -> 0.000085 |
| RT | 5 | 3 | 172,974 | 2 | 240 | 120 | 145 | 0.088 -> 0.090 | 2.60 -> 2.60 | 0.001074 -> 0.001067 |
| Q | 1 | 3 | 3,500 | 30 -> 40 | 365 -> 395 | 27 | 447 -> 451 | 0.139 -> 0.142 | 1.51 -> 1.55 | 0.000004 -> 0.000004 |
| Q | 5 | 3 | 95,761 | 17 -> 23 | 355 -> 505 | 49 | 334 -> 342 | 0.117 -> 0.120 | 1.32 -> 1.30 | 0.000088 -> 0.000085 |
| Q | 7 | 3 | 254,223 | 17 -> 23 | 583 -> 829 | 81 | 334 -> 342 | 0.115 -> 0.119 | 1.35 -> 1.35 | 0.000184 -> 0.000169 |
| NCE | 1 | 3 | 18,135 -> 18,168 | 98 -> 104 | 1,200 -> 1,218 | 27 | 868 -> 886 | 0.447 -> 0.455 | 3.20 -> 3.18 | 0.000016 -> 0.000015 |
| NCE | 5 | 3 | 386,797 -> 386,830 | 57 -> 63 | 1,887 -> 1,929 | 245 | 800 -> 832 | 0.443 -> 0.445 | 3.03 -> 3.08 | 0.000258 -> 0.000256 |
| NCE | 7 | 3 | 972,999 -> 973,032 | 57 -> 63 | 3,631 -> 3,685 | 567 | 800 -> 832 | 0.430 -> 0.447 | 3.09 -> 3.08 | 0.000682 -> 0.000682 |

Raviart--Thomas is again where the pullback is worth preserving, and now
correctly measured against `div`, not `curl`: arithmetic falls 10.4%, 13.8%
and 18.1% at degree 1, 3 and 5 in 2D, and 9.3%, 19.7% and 24.3% in 3D. CG only
moves at degree 1, where preserving the map is cheaper than expanding it
(-6.3% in 2D, -9.8% in 3D); at degree 3 and 5 the cost comparison below picks
expansion instead, so flops are unchanged.

**The tensor-product rows move only by what #282 already changed.** Q is
flop-for-flop identical between `main` and this PR; NCE carries a small,
degree-independent +33 flops that is unrelated to this PR's mechanism (which
needs an argument axis NCE's tensor-product tabulation does not expose) --
it is an artifact of comparing against two different firedrake commits, one
of which `main`'s FIAT cannot avoid (see above).

### Zany elements, bilinear form

| element | dim | flops | array temps | entries | largest | AST lines | tsfc (s) | build (s) | kernel (s) |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Argyris | 2 | 38,663 | 6 | 126 | 21 | 431 | 0.206 -> 0.227 | 2.63 -> 2.66 | 0.000041 -> 0.000041 |
| Guzman--Neilan | 2 | 10,041 | 8 | 72 | 9 | 372 | 0.157 -> 0.182 | 1.52 -> 1.51 | 0.000011 -> 0.000011 |
| Guzman--Neilan | 3 | 384,767 -> 371,974 | 18 -> 28 | 288 -> 448 | 16 | 1,803 -> 1,258 | 0.810 -> 0.841 | 6.69 -> 4.95 | 0.001689 -> 0.001634 |
| Johnson--Mercier | 2 | 21,660 | 14 | 630 | 225 | 454 | 0.233 -> 0.269 | 1.80 -> 1.81 | 0.000023 -> 0.000024 |
| Johnson--Mercier | 3 | 533,683 | 26 | 4,536 | 1,764 | 1,993 | 1.000 -> 1.269 | 9.83 -> 9.98 | 0.001538 -> 0.001540 |

### Zany elements, matrix-free action

| element | dim | flops | array temps | entries | largest | AST lines | tsfc (s) | build (s) | kernel (s) |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Argyris | 2 | 6,632 | 3 | 63 | 21 | 427 | 0.233 -> 0.249 | 2.61 -> 2.64 | 0.000006 -> 0.000006 |
| Guzman--Neilan | 2 | 3,549 | 4 | 36 | 9 | 343 | 0.159 -> 0.182 | 1.42 -> 1.41 | 0.000004 -> 0.000005 |
| Guzman--Neilan | 3 | 106,236 | 9 | 144 | 16 | 1,559 | 0.734 -> 0.864 | 5.52 -> 5.56 | 0.000976 -> 0.000971 |
| Johnson--Mercier | 2 | 3,753 | 9 | 135 | 15 | 444 | 0.267 -> 0.289 | 1.75 -> 1.72 | 0.000005 -> 0.000005 |
| Johnson--Mercier | 3 | 35,992 | 17 | 714 | 42 | 1,911 | 1.241 -> 1.409 | 10.02 -> 10.27 | 0.000205 -> 0.000201 |

Argyris, Guzman--Neilan in 2D, and Johnson--Mercier are unchanged by this PR
alone: none of their sums span exactly one argument axis yet, so
`has_linear_maps` finds nothing to preserve. Guzman--Neilan in 3D is the one
zany case this PR alone moves: flops fall 3.3%, AST lines fall 30.2% (1,803
-> 1,258), and the isolated build time falls 26.1%. Johnson--Mercier and
Argyris need #281's padded transformation before there is a map worth this
PR's cost comparison preserving; see #281.

## The cost comparison is doing real work

`estimate_cost` is not a formality: it accepts preservation where it pays and
rejects it where it does not. Costing both plans for the same form gives

| case | expanded | preserved | chosen |
| --- | ---: | ---: | --- |
| CG degree 1, 2D | 152 | **142** | preserved |
| CG degree 1, 3D | 416 | **374** | preserved |
| CG degree 3, 2D | **8,125** | 8,305 | expanded |
| RT degree 3, 3D | 374,589 | **255,933** | preserved |
| RT degree 5, 3D | 12,965,694 | **8,711,463** | preserved |

CG degree 3 is why the earlier `len(free_indices) > 1` heuristic was not enough:
preserving its map costs more arithmetic than distributing it, and only a cost
model sees that. On the RT rows the estimate matches the kernel's own
`flop_count` exactly.

## Tests

`test_sum_factorise.py` builds a Laplacian element tensor from a mapped gradient
table, where test and trial apply the same map over their own argument index,
and covers that preserving the map leaves strictly fewer monomials than
distributing it; that COFFEE materialises one tensor for both axes; that the
preserved and expanded forms evaluate to the same matrix; that
`has_linear_maps` needs argument axes to find anything; and that `estimate_cost`
counts the contraction.

## Validation

- `pytest test/ --ignore=test/FIAT/regression` (2378 passed, 26 skipped, 31 xfailed, 1 xpassed)
- `tests/tsfc` and the three zany regression suites in
  firedrakeproject/firedrake#5362 (437 passed)

## AI assistance

Claude Code was used for implementation, benchmarking, and drafting this
section. The human contributor remains responsible for understanding,
validating, and maintaining the changes.
