### PR TITLE
Take the embedded superdegree per direction on a tensor product cell

### DIFF
--- a/finat/ufl/tensorproductelement.py
+++ b/finat/ufl/tensorproductelement.py
@@ -141,10 +141,11 @@ class TensorProductElement(FiniteElementBase):
 
     @property
     def embedded_superdegree(self):
-        """Doc."""
+        """The degree of the smallest Lagrange space that holds this element."""
         return max(e.embedded_superdegree for e in self.factor_elements)
 
     @property
     def embedded_subdegree(self):
         """Doc."""
-        return min(self.degree())
+    """The degree of the largest Lagrange space that is a subspace of this element."""
+    return min(e.embedded_subdegree for e in self.factor_elements)

--- a/finat/ufl/tensorproductelement.py
+++ b/finat/ufl/tensorproductelement.py
@@ -146,6 +146,5 @@ class TensorProductElement(FiniteElementBase):
 
     @property
     def embedded_subdegree(self):
-        """Doc."""
-    """The degree of the largest Lagrange space that is a subspace of this element."""
-    return min(e.embedded_subdegree for e in self.factor_elements)
+        """The degree of the largest Lagrange space that is a subspace of this element."""
+        return min(e.embedded_subdegree for e in self.factor_elements)

--- a/finat/ufl/tensorproductelement.py
+++ b/finat/ufl/tensorproductelement.py
@@ -142,7 +142,7 @@ class TensorProductElement(FiniteElementBase):
     @property
     def embedded_superdegree(self):
         """Doc."""
-        return sum(self.degree())
+        return max(e.embedded_superdegree for e in self.factor_elements)
 
     @property
     def embedded_subdegree(self):


### PR DESCRIPTION
## The problem

`TensorProductElement.embedded_superdegree` adds the degree of each factor.

UFL defines the embedded superdegree as the degree of the smallest Lagrange
space that holds this element. The docstring of that property says that the
Lagrange space of degree 1 on a quadrilateral holds the polynomial `xy`. A
Lagrange space on a cell that is not a simplex is therefore a space of a given
degree in each direction, not a space of a given total degree.

A Q7 space on a `quadrilateral * interval` cell has degree 7 in each direction.
The smallest Lagrange space that holds it is the Q7 space itself, so the
embedded superdegree is 7. The property gives 14, because it adds 7 and 7.

The same space on a hexahedron gives 7, because a hexahedron element is not a
tensor product element. Two cells that hold the same space therefore give
different answers.

UFL estimates a quadrature degree from this property. For
`inner(grad(u), grad(v))*dx` on the extruded cell, UFL gives 26 in place of 14.
FIAT then applies 26 to each direction of the cell.

## The change

`embedded_superdegree` now takes the largest embedded superdegree of the
factors. The definition of the property does not change.

## Effect

An extruded mesh of quadrilaterals, with the fix in FEniCS/ufl#506.

| form | points before | points after | flops before | flops after |
| --- | ---: | ---: | ---: | ---: |
| Q7 `inner(grad(u), grad(v))*dx` | 3375 | 729 | 33,516,981 | 15,941,187 |
| NCE7 `inner(curl(u), curl(v))*dx` | 3375 | 729 | 253,603,812 | 115,918,062 |

Each matrix agrees with a rule of degree 32 to machine precision.

AI declaration: written with Claude Code (Claude Opus 5).
