### PR TITLE
Leave the point indices free in dual evaluation

### DIFF
--- a/finat/enriched.py
+++ b/finat/enriched.py
@@ -165,16 +165,17 @@ class EnrichedElement(FiniteElementBase):
                 f"Dual evaluation not defined for element {type(self).__name__}"
             )
         # Gather results from all sub-elements
-        # Each sub_result is (eval_expr, local_indices)
+        # Each sub_result is (eval_expr, point_indices, local_indices)
         sub_results = [sub.dual_evaluation(argument, coordinate_mapping=coordinate_mapping)
                        for sub in self.elements]
 
-        # Extract the evaluation sub-expressions
+        # Extract the evaluation sub-expressions, contracting each over its own points.
         # We must ensure that all subindices are in the free indices of subexpr
         # before wrapping in ComponentTensor. If some are missing (e.g. if the
         # expression simplified to a constant), we multiply by a dummy ones tensor.
         evals = []
-        for sub, (subexpr, subindices) in zip(self.elements, sub_results):
+        for subexpr, point_indices, subindices in sub_results:
+            subexpr = gem.IndexSum(subexpr, point_indices)
             missing_indices = tuple(idx for idx in subindices if idx not in subexpr.free_indices)
             if missing_indices:
                 shape = tuple(idx.extent for idx in missing_indices)
@@ -185,7 +186,7 @@ class EnrichedElement(FiniteElementBase):
 
         beta = self.get_indices()
         expr = gem.Indexed(gem.Concatenate(*evals), beta)
-        return expr, beta
+        return expr, (), beta
 
 
 def tree_map(f, *args):

--- a/finat/finiteelementbase.py
+++ b/finat/finiteelementbase.py
@@ -4,8 +4,6 @@ from itertools import chain
 import gem
 import numpy
 from gem.interpreter import evaluate
-from gem.optimise import (delta_elimination, is_contraction, sum_factorise,
-                          traverse_product)
 from gem.utils import cached_property
 
 from finat.quadrature import make_quadrature
@@ -256,22 +254,18 @@ class FiniteElementBase(metaclass=ABCMeta):
         :param coordinate_mapping: a
            :class:`~.physically_mapped.PhysicalGeometry` object that
            provides physical geometry callbacks (may be None).
-        :returns: A tuple ``(dual_evaluation_gem_expression, basis_indices)``
-                  where the given ``basis_indices`` are those needed to form a
-                  return expression for the code which is compiled from
-                  ``dual_evaluation_gem_expression`` (alongside any argument
+        :returns: A tuple ``(evaluation, point_indices, basis_indices)`` where
+                  ``evaluation`` is summed over the value shape but still has
+                  ``point_indices`` free, leaving the caller to choose how to
+                  contract over the points. The given ``basis_indices`` are
+                  those needed to form a return expression for the code which
+                  is compiled from ``evaluation`` (alongside any argument
                   multiindices already encoded within ``fn``)
         '''
         Q, x = self.dual_basis
         Q = self.dual_transformation(Q, coordinate_mapping=coordinate_mapping)
 
         expr = fn(x)
-        # Apply targeted sum factorisation and delta elimination to
-        # the expression, preserving contractions that fn already factorised
-        # FIXME: a single pass of gem.optimise.contraction will choke on too many indices
-        # This is a temporary workaround https://github.com/firedrakeproject/fiat/issues/283
-        sum_indices, factors = delta_elimination(*traverse_product(expr, stop_at=is_contraction))
-        expr = sum_factorise(sum_indices, factors)
         # NOTE: any shape indices in the expression are because the
         # expression is tensor valued.
         assert expr.shape == Q.shape[len(Q.shape)-len(expr.shape):]
@@ -279,11 +273,8 @@ class FiniteElementBase(metaclass=ABCMeta):
         basis_indices = gem.indices(len(Q.shape) - len(expr.shape))
         Qi = Q[basis_indices + shape_indices]
         expri = expr[shape_indices]
-        evaluation = gem.IndexSum(Qi * expri, x.indices + shape_indices)
-        # Factorise over the new contraction with Qi, keeping whole the
-        # contractions that fn already factorised
-        evaluation = gem.optimise.contraction(evaluation, stop_at=is_contraction)
-        return evaluation, basis_indices
+        evaluation = gem.IndexSum(Qi * expri, shape_indices)
+        return evaluation, x.indices, basis_indices
 
     def dual_transformation(self, Q, coordinate_mapping=None):
         """Transforms reference dual evaluation into physical dual evaluation.

--- a/finat/tensorfiniteelement.py
+++ b/finat/tensorfiniteelement.py
@@ -3,8 +3,6 @@ from itertools import chain
 import numpy
 
 import gem
-from gem.optimise import (delta_elimination, is_contraction, sum_factorise,
-                          traverse_product)
 from gem.utils import cached_property
 
 from finat.finiteelementbase import FiniteElementBase
@@ -177,12 +175,6 @@ class TensorFiniteElement(FiniteElementBase):
         tQ = self._base_element.dual_transformation(tQ, coordinate_mapping)
 
         expr = fn(x)
-        # Apply targeted sum factorisation and delta elimination to
-        # the expression, preserving contractions that fn already factorised
-        # FIXME: a single pass of gem.optimise.contraction will choke on too many indices
-        # This is a temporary workaround https://github.com/firedrakeproject/fiat/issues/283
-        sum_indices, factors = delta_elimination(*traverse_product(expr, stop_at=is_contraction))
-        expr = sum_factorise(sum_indices, factors)
         # NOTE: any shape indices in the expression are because the
         # expression is tensor valued.
         assert expr.shape == self.value_shape
@@ -199,12 +191,8 @@ class TensorFiniteElement(FiniteElementBase):
 
         tQi = tQ[index_ordering]
         expri = expr[tensor_i + scalar_vi]
-        evaluation = gem.IndexSum(tQi * expri, x.indices + scalar_vi + tensor_i)
-        # This doesn't work perfectly, the resulting code doesn't have
-        # a minimal memory footprint, although the operation count
-        # does appear to be minimal.
-        evaluation = gem.optimise.contraction(evaluation, stop_at=is_contraction)
-        return evaluation, scalar_i + tensor_vi
+        evaluation = gem.IndexSum(tQi * expri, scalar_vi + tensor_i)
+        return evaluation, x.indices, scalar_i + tensor_vi
 
     @property
     def mapping(self):

--- a/gem/optimise.py
+++ b/gem/optimise.py
@@ -630,41 +630,12 @@ def traverse_sum(expression, stop_at=None):
     return result
 
 
-def is_contraction(expression: Node) -> bool:
-    """Test whether an expression is a tensor contraction.
-
-    Parameters
-    ----------
-    expression :
-        A GEM expression.
-
-    Returns
-    -------
-    bool
-        Whether the expression is a contraction.
-
-    Notes
-    -----
-    Pass this as ``stop_at`` to keep a contraction that is already sum
-    factorised out of a surrounding one. Flattening it discards its
-    factorisation, along with any subexpression it shares with another
-    factor, and inflates the number of indices to factorise over.
-
-    """
-    return isinstance(expression, IndexSum)
-
-
-def contraction(expression, stop_at=None):
+def contraction(expression):
     """Optimise the contractions of the tensor product at the root of
     the expression, including:
 
     - IndexSum-Delta cancellation
     - Sum factorisation
-
-    :arg stop_at: Optional predicate on GEM expressions that are not to
-        be broken into further factors, see :func:`traverse_product`.
-        The contraction at the root is always broken up, as that is the
-        one being optimised.
 
     This routine was designed with finite element coefficient
     evaluation in mind.
@@ -678,10 +649,7 @@ def contraction(expression, stop_at=None):
 
     # Flatten product tree, eliminate deltas, sum factorise
     def rebuild(expression):
-        root = expression
-        sum_indices, factors = traverse_product(
-            expression, index_replacer=index_replacer,
-            stop_at=None if stop_at is None else lambda e: e is not root and stop_at(e))
+        sum_indices, factors = traverse_product(expression, index_replacer=index_replacer)
         sum_indices, factors = delta_elimination(sum_indices, factors, index_replacer=index_replacer)
         factors = [index_replacer(f, ()) for f in factors]
         return sum_factorise(sum_indices, factors)

--- a/test/finat/test_dual_basis.py
+++ b/test/finat/test_dual_basis.py
@@ -41,11 +41,11 @@ def test_enriched_element_dual_evaluation():
 
     # Check that calling dual_evaluation returns a valid Indexed expression
     fn = lambda x: gem.Literal(1.0)
-    expr, indices = enriched.dual_evaluation(fn)
+    expr, point_indices, basis_indices = enriched.dual_evaluation(fn)
     assert isinstance(expr, gem.Indexed)
     assert isinstance(expr.children[0], gem.Concatenate)
-    assert len(indices) == 1
-    assert indices[0].extent == enriched.space_dimension()
+    assert len(basis_indices) == 1
+    assert basis_indices[0].extent == enriched.space_dimension()
 
 
 @pytest.fixture(scope="module")
@@ -67,7 +67,8 @@ def coefficient_evaluation(element, ps, dofs):
 
 def nodal_values(element, fn):
     """Dual evaluate fn against a nodal element, giving its values at the nodes."""
-    expression, indices = element.dual_evaluation(fn)
+    expression, point_indices, basis_indices = element.dual_evaluation(fn)
+    indices = point_indices + basis_indices
     result, = evaluate([gem.ComponentTensor(expression, indices)])
     return result.arr
 

--- a/test/gem/test_sum_factorise.py
+++ b/test/gem/test_sum_factorise.py
@@ -3,8 +3,6 @@ import pytest
 
 import gem
 from gem.interpreter import evaluate
-from gem import optimise
-from gem.node import traversal
 from gem.optimise import sum_factorise
 
 
@@ -52,33 +50,3 @@ def test_too_many_indices_in_one_contraction():
     table = gem.Indexed(gem.Literal(numpy.ones((2,) * 7)), indices)
     with pytest.raises(NotImplementedError):
         sum_factorise(indices, [table])
-
-
-def test_contraction_preserves_factorised_contractions():
-    # A dual evaluation contracts the weights with an expression whose
-    # coefficient evaluations are already sum factorised.  Those carry the
-    # point index of the contraction, so flattening them yields a single
-    # connected contraction that is too large to factorise.
-    numpy.random.seed(0)
-    p, q = gem.Index(extent=4), gem.Index(extent=4)
-    ijk = tuple(gem.Index(extent=3) for _ in range(3))
-
-    table = gem.Indexed(gem.Literal(numpy.random.rand(3, 3, 3, 4)), ijk + (p,))
-    dofs = numpy.random.rand(3, 3, 3)
-    evaluation = optimise.contraction(gem.IndexSum(gem.Product(table, gem.Indexed(gem.Literal(dofs), ijk)), ijk))
-    assert optimise.is_contraction(evaluation)
-
-    weights = numpy.random.rand(4, 4)
-    cubed = gem.Product(gem.Product(gem.Indexed(gem.Literal(weights), (q, p)), evaluation),
-                        gem.Product(evaluation, evaluation))
-    expression = gem.IndexSum(cubed, (p,))
-
-    with pytest.raises(NotImplementedError):
-        optimise.contraction(expression)
-
-    optimised = optimise.contraction(expression, stop_at=optimise.is_contraction)
-    assert evaluation in set(traversal([optimised]))
-
-    result, = evaluate([gem.ComponentTensor(optimised, (q,))])
-    expected = weights.dot(numpy.einsum("ijkp,ijk->p", numpy.asarray(table.children[0].array), dofs) ** 3)
-    assert numpy.allclose(result.arr, expected)


### PR DESCRIPTION
Fixes #283 by making `dual_evaluation` no longer have to sum-factorise internally

`dual_evaluation` returns `(evaluation, point_indices, basis_indices)`, summing only over the value shape. 

TSFC now chooses how to contract over the points, matching `basis_evaluation`, which already leaves the point index free.